### PR TITLE
fix: Add condition that pushes code to CodeCommit only CODE_COMMIT_REPO secret is defined

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CodeCommitSync
+name: "Push code to AWS CodeCommit"
 
 on:
   push:
@@ -15,6 +15,7 @@ jobs:
       - shell: bash
         env:
           CODE_COMMIT_REPO: ${{ secrets.CODE_COMMIT_REPO }}
+        if: env.CODE_COMMIT_REPO != ''
         run: |
           git remote add codecommit "$CODE_COMMIT_REPO"
           git push -u codecommit ${GITHUB_REF#refs/heads/} --force


### PR DESCRIPTION
* **What kind of change does this PR introduce?**
Bug fix

* **What is the current behavior?**
Pull requests that do not have access to github secrets (like dependabot) fail build because of CodeCommit syn job.


* **What is the new behavior ?**
CodeCommit job does not run when CODE_COMMIT_REPO env var is not defined.

* **Does this PR introduce a breaking change?**
no
