### PR TITLE
fix: Add command that runs all setup targets to make sure all .env files are created

### DIFF
--- a/packages/internal/core/project.json
+++ b/packages/internal/core/project.json
@@ -41,6 +41,7 @@
         "color": true,
         "parallel": false,
         "commands": [
+          "nx run-many --target=setup",
           "nx run-many --target=compose-build-image --projects=backend,workers",
           "docker-compose up --force-recreate -d backend workers"
         ]

--- a/packages/internal/ssm-editor/project.json
+++ b/packages/internal/ssm-editor/project.json
@@ -9,7 +9,7 @@
       "options": {
         "color": true,
         "cwd": "packages/internal/ssm-editor",
-        "command": ""
+        "command": "echo skip"
       }
     },
     "compose-build-image": {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)

### What kind of change does this PR introduce?

Closes #177 

### What is the current behavior?

`make up` fails if `.env` file does not exist in packages/e2e-tests

### What is the new behavior?

`.env.` file is automatically created when `make up` is run.

### Does this PR introduce a breaking change?

no

### Other information:

Make sure you run `nx reset` to remove `nx` cache before you run `make up` if you encountered the error