### PR TITLE
fix: #181 Migrate from CloudFrontWebDistribution to the newer Distribution

### DIFF
--- a/packages/infra/infra-shared/src/stacks/usEastResources/authLambda/index.js
+++ b/packages/infra/infra-shared/src/stacks/usEastResources/authLambda/index.js
@@ -2,13 +2,23 @@ exports.handler = (event, context, callback) => {
   checkCredentials(event, context, callback);
 };
 
+const getAuthString = (request) => {
+  const headerName = 'x-auth-string';
+  if (request.origin.s3) {
+    return 'Basic ' + request.origin.s3.customHeaders[headerName][0].value;
+  }
+  return 'Basic ' + request.origin.custom.customHeaders[headerName][0].value;
+}
+
 function checkCredentials(event, context, callback) {
+  console.log(JSON.stringify(event, undefined,2));
+
   // Get the request and its headers
   const request = event.Records[0].cf.request;
   const headers = request.headers;
 
   // Build a Basic Authentication string
-  const authString = 'Basic ' + request.origin.custom.customHeaders['x-auth-string'][0].value;
+  const authString = getAuthString(request);
 
   // Challenge for auth if auth credentials are absent or incorrect
   if (typeof headers.authorization == 'undefined' || headers.authorization[0].value !== authString) {

--- a/packages/infra/infra-shared/src/stacks/usEastResources/stack.ts
+++ b/packages/infra/infra-shared/src/stacks/usEastResources/stack.ts
@@ -44,7 +44,7 @@ export class UsEastResourcesStack extends Stack {
     );
 
     const authFunction = new lambda.Function(this, 'AuthFunction', {
-      runtime: lambda.Runtime.NODEJS_12_X,
+      runtime: lambda.Runtime.NODEJS_18_X,
       code: lambda.Code.fromAsset(path.join(__dirname, 'authLambda')),
       handler: 'index.handler',
       role: executionRole,

--- a/packages/internal/docs/infra/stacks/docs/stack.ts
+++ b/packages/internal/docs/infra/stacks/docs/stack.ts
@@ -31,13 +31,13 @@ export class DocsStack extends Stack {
           sources: [s3Deployment.Source.asset(filesPath)],
           domainZone,
           domainName: props.envSettings.domains.docs,
-          apiDomainName: props.envSettings.domains.api,
           certificateArn,
           authLambdaSSMParameterName:
             UsEastResourcesStack.getAuthLambdaVersionArnSSMParameterName(
               props.envSettings
             ),
           distributionPaths: ['/*'],
+          basicAuth: props.envSettings.appBasicAuth,
         }
       );
     }


### PR DESCRIPTION
Migrate from CloudFrontWebDistribution to the newer Distribution construct, fix WepAppStack deployment

### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Fixes #181 

### What is the current behavior?

Fresh deployment of WebAppStack fails because of the new S3 default policy.

### What is the new behavior?

Issue with the fresh installation is now gone.
