### PR TITLE
feat: Implement more restrictive permissions for access to SSM parame…

### DIFF
--- a/packages/infra/infra-shared/src/stacks/bootstrap/stack.ts
+++ b/packages/infra/infra-shared/src/stacks/bootstrap/stack.ts
@@ -1,15 +1,53 @@
 import { App, Stack, StackProps } from 'aws-cdk-lib';
 import * as kms from 'aws-cdk-lib/aws-kms';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import { EnvironmentSettings } from '@sb/infra-core';
 
 export class BootstrapStack extends Stack {
   key: kms.Key;
+
+  static getParameterStoreKeyAlias() {
+    return 'alias/parameter_store_key';
+  }
+
+  static getIamPolicyStatementsForEnvParameters(
+    envSettings: EnvironmentSettings
+  ) {
+    const alias = BootstrapStack.getParameterStoreKeyAlias();
+    return [
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'kms:Get*',
+          'kms:Describe*',
+          'kms:List*',
+          'kms:Decrypt',
+          'kms:Verify',
+        ],
+        resources: ['*'],
+        conditions: {
+          StringEquals: { 'kms:RequestAlias': alias },
+          'ForAnyValue:StringEquals': { 'kms:ResourceAliases': alias },
+        },
+      }),
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['ssm:DescribeParameters'],
+        resources: ['*'],
+      }),
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['ssm:GetParameter*'],
+        resources: [`arn:aws:ssm:::parameter/${envSettings.envStage}*`],
+      }),
+    ];
+  }
 
   constructor(scope: App, id: string, props?: StackProps) {
     super(scope, id, props);
 
     this.key = new kms.Key(this, 'Key', {
-      alias: 'alias/parameter_store_key',
+      alias: BootstrapStack.getParameterStoreKeyAlias(),
     });
 
     this.key.addToResourcePolicy(

--- a/packages/infra/infra-shared/src/stacks/ci/ciBackend.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciBackend.ts
@@ -6,6 +6,8 @@ import * as codepipeline from 'aws-cdk-lib/aws-codepipeline';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { EnvConstructProps, ServiceCiConfig } from '@sb/infra-core';
+import { BootstrapStack } from '../bootstrap';
+import { EnvMainStack } from '../main';
 
 interface BackendCiConfigProps extends EnvConstructProps {
   inputArtifact: codepipeline.Artifact;
@@ -109,13 +111,13 @@ export class BackendCiConfig extends ServiceCiConfig {
       cache: codebuild.Cache.local(codebuild.LocalCacheMode.DOCKER_LAYER),
     });
 
-    project.addToRolePolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['kms:*', 'ssm:*'],
-        resources: ['*'],
-      })
-    );
+    BootstrapStack.getIamPolicyStatementsForEnvParameters(
+      props.envSettings
+    ).forEach((statement) => project.addToRolePolicy(statement));
+
+    EnvMainStack.getIamPolicyStatementsForEnvParameters(
+      props.envSettings
+    ).forEach((statement) => project.addToRolePolicy(statement));
 
     project.addToRolePolicy(
       new iam.PolicyStatement({
@@ -183,13 +185,13 @@ export class BackendCiConfig extends ServiceCiConfig {
       })
     );
 
-    project.addToRolePolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['kms:*', 'ssm:*'],
-        resources: ['*'],
-      })
-    );
+    BootstrapStack.getIamPolicyStatementsForEnvParameters(
+      props.envSettings
+    ).forEach((statement) => project.addToRolePolicy(statement));
+
+    EnvMainStack.getIamPolicyStatementsForEnvParameters(
+      props.envSettings
+    ).forEach((statement) => project.addToRolePolicy(statement));
 
     project.addToRolePolicy(
       new iam.PolicyStatement({
@@ -250,6 +252,14 @@ export class BackendCiConfig extends ServiceCiConfig {
         ],
       })
     );
+
+    BootstrapStack.getIamPolicyStatementsForEnvParameters(
+      props.envSettings
+    ).forEach((statement) => project.addToRolePolicy(statement));
+
+    EnvMainStack.getIamPolicyStatementsForEnvParameters(
+      props.envSettings
+    ).forEach((statement) => project.addToRolePolicy(statement));
 
     project.addToRolePolicy(
       new iam.PolicyStatement({

--- a/packages/infra/infra-shared/src/stacks/ci/ciComponents.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciComponents.ts
@@ -14,7 +14,6 @@ import {
 import { Artifact, IStage } from 'aws-cdk-lib/aws-codepipeline';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { EnvConstructProps, ServiceCiConfig } from '@sb/infra-core';
-import * as iam from 'aws-cdk-lib/aws-iam';
 import { BootstrapStack } from '../bootstrap';
 import { EnvMainStack } from '../main';
 

--- a/packages/infra/infra-shared/src/stacks/ci/ciComponents.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciComponents.ts
@@ -15,6 +15,8 @@ import { Artifact, IStage } from 'aws-cdk-lib/aws-codepipeline';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { EnvConstructProps, ServiceCiConfig } from '@sb/infra-core';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import { BootstrapStack } from '../bootstrap';
+import { EnvMainStack } from '../main';
 
 interface ComponentsCiConfigProps extends EnvConstructProps {
   inputArtifact: Artifact;
@@ -88,13 +90,13 @@ export class ComponentsCiConfig extends ServiceCiConfig {
       })
     );
 
-    project.addToRolePolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['kms:*', 'ssm:*'],
-        resources: ['*'],
-      })
-    );
+    BootstrapStack.getIamPolicyStatementsForEnvParameters(
+      props.envSettings
+    ).forEach((statement) => project.addToRolePolicy(statement));
+
+    EnvMainStack.getIamPolicyStatementsForEnvParameters(
+      props.envSettings
+    ).forEach((statement) => project.addToRolePolicy(statement));
 
     project.addToRolePolicy(
       new PolicyStatement({

--- a/packages/infra/infra-shared/src/stacks/ci/ciDocs.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciDocs.ts
@@ -5,6 +5,8 @@ import * as codepipeline from 'aws-cdk-lib/aws-codepipeline';
 import * as codepipelineActions from 'aws-cdk-lib/aws-codepipeline-actions';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { EnvConstructProps, ServiceCiConfig } from '@sb/infra-core';
+import { BootstrapStack } from '../bootstrap';
+import { EnvMainStack } from '../main';
 
 interface DocsCiConfigProps extends EnvConstructProps {
   inputArtifact: codepipeline.Artifact;
@@ -97,13 +99,13 @@ export class DocsCiConfig extends ServiceCiConfig {
       cache: codebuild.Cache.local(codebuild.LocalCacheMode.DOCKER_LAYER),
     });
 
-    project.addToRolePolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['kms:*', 'ssm:*'],
-        resources: ['*'],
-      })
-    );
+    BootstrapStack.getIamPolicyStatementsForEnvParameters(
+      props.envSettings
+    ).forEach((statement) => project.addToRolePolicy(statement));
+
+    EnvMainStack.getIamPolicyStatementsForEnvParameters(
+      props.envSettings
+    ).forEach((statement) => project.addToRolePolicy(statement));
 
     return project;
   }
@@ -159,13 +161,13 @@ export class DocsCiConfig extends ServiceCiConfig {
       })
     );
 
-    project.addToRolePolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['kms:*', 'ssm:*'],
-        resources: ['*'],
-      })
-    );
+    BootstrapStack.getIamPolicyStatementsForEnvParameters(
+      props.envSettings
+    ).forEach((statement) => project.addToRolePolicy(statement));
+
+    EnvMainStack.getIamPolicyStatementsForEnvParameters(
+      props.envSettings
+    ).forEach((statement) => project.addToRolePolicy(statement));
 
     project.addToRolePolicy(
       new iam.PolicyStatement({

--- a/packages/infra/infra-shared/src/stacks/ci/ciUploadVersion.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciUploadVersion.ts
@@ -4,6 +4,8 @@ import * as codebuildActions from 'aws-cdk-lib/aws-codepipeline-actions';
 import * as codepipeline from 'aws-cdk-lib/aws-codepipeline';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { EnvConstructProps, ServiceCiConfig } from '@sb/infra-core';
+import { BootstrapStack } from '../bootstrap';
+import { EnvMainStack } from '../main';
 
 interface UploadVersionCiConfigProps extends EnvConstructProps {
   inputArtifact: codepipeline.Artifact;
@@ -71,13 +73,13 @@ export class UploadVersionCiConfig extends ServiceCiConfig {
       cache: codebuild.Cache.local(codebuild.LocalCacheMode.CUSTOM),
     });
 
-    project.addToRolePolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['kms:*', 'ssm:*'],
-        resources: ['*'],
-      })
-    );
+    BootstrapStack.getIamPolicyStatementsForEnvParameters(
+      props.envSettings
+    ).forEach((statement) => project.addToRolePolicy(statement));
+
+    EnvMainStack.getIamPolicyStatementsForEnvParameters(
+      props.envSettings
+    ).forEach((statement) => project.addToRolePolicy(statement));
 
     project.addToRolePolicy(
       new iam.PolicyStatement({

--- a/packages/infra/infra-shared/src/stacks/ci/ciWebApp.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciWebApp.ts
@@ -5,6 +5,8 @@ import * as codepipelineActions from 'aws-cdk-lib/aws-codepipeline-actions';
 import * as codepipeline from 'aws-cdk-lib/aws-codepipeline';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { EnvConstructProps, ServiceCiConfig } from '@sb/infra-core';
+import { BootstrapStack } from '../bootstrap';
+import { EnvMainStack } from '../main';
 
 interface WebAppCiConfigProps extends EnvConstructProps {
   inputArtifact: codepipeline.Artifact;
@@ -113,13 +115,13 @@ export class WebappCiConfig extends ServiceCiConfig {
       cache: codebuild.Cache.local(codebuild.LocalCacheMode.DOCKER_LAYER),
     });
 
-    project.addToRolePolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['kms:*', 'ssm:*'],
-        resources: ['*'],
-      })
-    );
+    BootstrapStack.getIamPolicyStatementsForEnvParameters(
+      props.envSettings
+    ).forEach((statement) => project.addToRolePolicy(statement));
+
+    EnvMainStack.getIamPolicyStatementsForEnvParameters(
+      props.envSettings
+    ).forEach((statement) => project.addToRolePolicy(statement));
 
     return project;
   }
@@ -164,13 +166,13 @@ export class WebappCiConfig extends ServiceCiConfig {
       cache: codebuild.Cache.local(codebuild.LocalCacheMode.CUSTOM),
     });
 
-    project.addToRolePolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['kms:*', 'ssm:*'],
-        resources: ['*'],
-      })
-    );
+    BootstrapStack.getIamPolicyStatementsForEnvParameters(
+      props.envSettings
+    ).forEach((statement) => project.addToRolePolicy(statement));
+
+    EnvMainStack.getIamPolicyStatementsForEnvParameters(
+      props.envSettings
+    ).forEach((statement) => project.addToRolePolicy(statement));
 
     project.addToRolePolicy(
       new iam.PolicyStatement({

--- a/packages/infra/infra-shared/src/stacks/main/mainKmsKey.ts
+++ b/packages/infra/infra-shared/src/stacks/main/mainKmsKey.ts
@@ -2,10 +2,7 @@ import { Construct } from 'constructs';
 import { CfnOutput } from 'aws-cdk-lib';
 import * as kms from 'aws-cdk-lib/aws-kms';
 import * as iam from 'aws-cdk-lib/aws-iam';
-import {
-  EnvConstructProps,
-  EnvironmentSettings,
-} from '@sb/infra-core';
+import { EnvConstructProps, EnvironmentSettings } from '@sb/infra-core';
 
 export class MainKmsKey extends Construct {
   key: kms.Key;
@@ -19,6 +16,7 @@ export class MainKmsKey extends Construct {
   static getMainKmsOutputExportName(envSettings: EnvironmentSettings) {
     return `${envSettings.projectEnvName}-mainKmsKeyArn`;
   }
+
 
   constructor(scope: Construct, id: string, props: EnvConstructProps) {
     super(scope, id);

--- a/packages/infra/infra-shared/src/stacks/main/stack.ts
+++ b/packages/infra/infra-shared/src/stacks/main/stack.ts
@@ -47,23 +47,23 @@ export class EnvMainStack extends Stack {
   }
 
   static getIamPolicyStatementsForEnvParameters(
-    envSettings: EnvironmentSettings
+    envSettings: EnvironmentSettings,
+    region = '*',
+    account = '*'
   ) {
     const alias = MainKmsKey.getKeyAlias(envSettings);
     return [
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
-        actions: [
-          'kms:Get*',
-          'kms:Describe*',
-          'kms:List*',
-          'kms:Decrypt',
-          'kms:Verify',
-        ],
+        actions: ['kms:Decrypt'],
         resources: ['*'],
         conditions: {
-          StringEquals: { 'kms:RequestAlias': alias },
-          'ForAnyValue:StringEquals': { 'kms:ResourceAliases': alias },
+          'ForAllValues:StringLike': {
+            'kms:ResourceAliases': [`alias/*${alias}*`],
+          },
+          'ForAnyValue:StringLike': {
+            'kms:ResourceAliases': [`alias/*${alias}*`],
+          },
         },
       }),
       new iam.PolicyStatement({
@@ -75,7 +75,7 @@ export class EnvMainStack extends Stack {
         effect: iam.Effect.ALLOW,
         actions: ['ssm:GetParameter*'],
         resources: [
-          `arn:aws:ssm:::parameter/env-${envSettings.projectName}-${envSettings.envStage}*`,
+          `arn:aws:ssm:${region}:${account}:parameter/env-${envSettings.projectName}-${envSettings.envStage}-*`,
         ],
       }),
     ];

--- a/packages/workers/Dockerfile
+++ b/packages/workers/Dockerfile
@@ -1,3 +1,9 @@
+##
+# Chamber installation stage
+##
+
+FROM segment/chamber:2 AS chamber
+
 FROM python:3.9-slim-bullseye
 
 ENV APP_PATH=/app
@@ -16,6 +22,8 @@ RUN \
   pip install -U pip~=23.0.1 && pip install "urllib3<2" pdm~=2.5.2 && \
   npm i -g npm@^8 pnpm@^8.6.1 && \
   rm -rf /var/lib/apt/lists/*
+
+COPY --from=chamber /chamber /bin/chamber
 
 WORKDIR /pkgs
 COPY packages/workers/pdm.lock packages/workers/pyproject.toml packages/workers/.pdm.toml /pkgs/


### PR DESCRIPTION
…ter store and KMS keys

### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines

### What kind of change does this PR introduce?

feature

### What is the current behavior?

Currently CodeBuild projects have "kms:*" and "ssm:*" permissions on all resources.

### What is the new behavior?

Limit access only to `parameter_store_key` and to main key of the particular env stage.

### Does this PR introduce a breaking change?

no

