### PR TITLE
fix: Use ECR public images with Pull-Through-Cache inside AWS CodePipeline

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ '**' ]
 
+env:
+  BACKEND_BASE_IMAGE: python:3.11-slim-bullseye
+
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ '**' ]
 
+env:
+  BACKEND_BASE_IMAGE: python:3.11-slim-bullseye
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/workers.yml
+++ b/.github/workflows/workers.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ '**' ]
 
+env:
+  WORKERS_BASE_IMAGE: python:3.9-slim-bullseye
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -7,6 +7,9 @@ services:
       - ./packages/backend/docs:/app/docs
     environment:
       - CI=true
+    build:
+      args:
+        - BACKEND_BASE_IMAGE=${BACKEND_BASE_IMAGE}
 
   workers:
     volumes:
@@ -22,6 +25,9 @@ services:
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
       - AWS_SECURITY_TOKEN=${AWS_SECURITY_TOKEN}
       - AWS_SESSION_EXPIRATION=${AWS_SESSION_EXPIRATION}
+    build:
+      args:
+        - WORKERS_BASE_IMAGE=${WORKERS_BASE_IMAGE}
 
   e2e-tests:
     environment:
@@ -33,3 +39,6 @@ services:
       - AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}
       - AWS_SECURITY_TOKEN=${AWS_SECURITY_TOKEN}
       - AWS_SESSION_EXPIRATION=${AWS_SESSION_EXPIRATION}
+    build:
+      args:
+        - E2E_TESTS_BASE_IMAGE=${E2E_TESTS_BASE_IMAGE}

--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -1,3 +1,4 @@
+ARG BACKEND_BASE_IMAGE=python:3.11-slim-bullseye
 ##
 # Chamber installation stage
 ##
@@ -7,8 +8,7 @@ FROM segment/chamber:2 AS chamber
 ##
 # App build stage
 ##
-
-FROM python:3.11-slim-bullseye AS backend_build
+FROM $BACKEND_BASE_IMAGE AS backend_build
 
 ENV PYTHONUNBUFFERED 1
 ENV PIP_NO_CACHE_DIR off

--- a/packages/backend/scripts/build.sh
+++ b/packages/backend/scripts/build.sh
@@ -15,7 +15,12 @@ fi
 
 docker pull "$BACKEND_REPO_URI:latest" || true
 
-docker build --target backend -t "$BACKEND_REPO_URI:$VERSION" .
+if [[ -z "${BACKEND_BASE_IMAGE}" ]]; then
+  docker build --target backend -t "$BACKEND_REPO_URI:$VERSION" .
+else
+  docker build --target backend -t "$BACKEND_REPO_URI:$VERSION" --build-arg BACKEND_BASE_IMAGE="$BACKEND_BASE_IMAGE" .
+fi
+
 docker push "$BACKEND_REPO_URI:$VERSION"
 
 docker tag "$BACKEND_REPO_URI:$VERSION" "$BACKEND_REPO_URI:latest"

--- a/packages/e2e-tests/Dockerfile
+++ b/packages/e2e-tests/Dockerfile
@@ -1,6 +1,8 @@
+ARG E2E_TESTS_BASE_IMAGE=cypress/included:12.3.0
+
 FROM segment/chamber:2 AS chamber
 
-FROM cypress/included:12.3.0 AS base
+FROM $E2E_TESTS_BASE_IMAGE AS base
 ENV APP_PATH=/home/node/app
 ENV SRC_CORE_PATH=packages/internal/core
 ENV CORE_PATH=$APP_PATH/$SRC_CORE_PATH

--- a/packages/infra/infra-core/src/lib/env-config.ts
+++ b/packages/infra/infra-core/src/lib/env-config.ts
@@ -22,6 +22,9 @@ declare const process: {
     SB_TOOLS_HOSTED_ZONE_NAME: string;
     SB_TOOLS_HOSTED_ZONE_ID: string;
     SB_TOOLS_DOMAIN_VERSION_MATRIX: string;
+    SB_BACKEND_BASE_IMAGE: string;
+    SB_WORKERS_BASE_IMAGE: string;
+    SB_E2E_TESTS_BASE_IMAGE: string;
   };
 };
 
@@ -64,6 +67,12 @@ interface WebAppConfig {
   envVariables: EnvironmentVariables;
 }
 
+interface DockerImages {
+  backendBaseImage: string;
+  workersBaseImage: string;
+  e2eTestsBaseImage: string;
+}
+
 export interface EnvironmentSettings {
   appBasicAuth: string | null | undefined;
   deployBranches: Array<string>;
@@ -77,6 +86,7 @@ export interface EnvironmentSettings {
   version: string;
   webAppEnvVariables: EnvironmentVariables;
   certificates: CertificatesConfig;
+  dockerImages: DockerImages;
 }
 
 interface ConfigFileContent {
@@ -91,6 +101,7 @@ export interface EnvConfigFileContent {
   domains: EnvConfigFileDomains;
   webAppConfig: WebAppConfig;
   certificates: CertificatesConfig;
+  dockerImages: DockerImages;
 }
 
 async function readConfig(): Promise<ConfigFileContent> {
@@ -137,6 +148,11 @@ async function readEnvConfig(): Promise<EnvConfigFileContent> {
       name: process.env.SB_HOSTED_ZONE_NAME ?? '',
     },
     deployBranches: process.env.SB_DEPLOY_BRANCHES?.split(',') ?? [],
+    dockerImages: {
+      backendBaseImage: process.env.SB_BACKEND_BASE_IMAGE ?? '',
+      workersBaseImage: process.env.SB_WORKERS_BASE_IMAGE ?? '',
+      e2eTestsBaseImage: process.env.SB_E2E_TESTS_BASE_IMAGE ?? '',
+    },
   };
 }
 
@@ -172,5 +188,6 @@ export async function loadEnvSettings(): Promise<EnvironmentSettings> {
       ...(envConfig?.webAppConfig?.envVariables || {}),
     },
     certificates: envConfig.certificates,
+    dockerImages: envConfig.dockerImages,
   };
 }

--- a/packages/infra/infra-core/src/lib/patterns/serviceCiConfig.ts
+++ b/packages/infra/infra-core/src/lib/patterns/serviceCiConfig.ts
@@ -1,11 +1,24 @@
 import { Construct } from 'constructs';
 import * as codebuild from 'aws-cdk-lib/aws-codebuild';
 import { EnvConstructProps } from '../constructs';
+import { Fn } from 'aws-cdk-lib';
 
 export interface IServiceCiConfig {
   defaultEnvVariables: {
     [name: string]: codebuild.BuildEnvironmentVariable;
   };
+}
+
+export enum PnpmWorkspaceFilters {
+  BACKEND = 'backend',
+  INFRA_SHARED = 'infra-shared',
+  DOCS = 'docs',
+  WEBAPP_EMAILS = 'webapp-emails',
+  WORKERS = 'workers',
+  CORE = 'core',
+  TOOLS = 'tools',
+  WEBAPP = 'webapp...',
+  E2E_TESTS = 'e2e-tests^...',
 }
 
 export class ServiceCiConfig extends Construct implements IServiceCiConfig {
@@ -31,5 +44,39 @@ export class ServiceCiConfig extends Construct implements IServiceCiConfig {
     };
 
     this.defaultCachePaths = ['~/.pnpm-store'];
+  }
+
+  protected getWorkspaceSetupCommands(
+    ...pnpmWorkspaceFilters: PnpmWorkspaceFilters[]
+  ) {
+    const filters = pnpmWorkspaceFilters.map(
+      (workspace) => ` --filter=${workspace}`
+    );
+
+    return [
+      'go install github.com/segmentio/chamber/v2@latest',
+      'npm i -g pnpm@^8.6.1',
+      `pnpm install \
+                --include-workspace-root \
+                --frozen-lockfile`.concat(...filters),
+    ];
+  }
+
+  protected getECRLoginCommand() {
+    const awsRegion = Fn.ref('AWS::Region');
+    const awsAccountId = Fn.ref('AWS::AccountId');
+
+    return `aws ecr get-login-password --region ${awsRegion} \
+       | docker login --username AWS --password-stdin ${awsAccountId}.dkr.ecr.${awsRegion}.amazonaws.com`;
+  }
+
+  protected getAssumeRoleCommands() {
+    return [
+      'TEMP_ROLE=`aws sts assume-role --role-arn $ASSUME_ROLE_ARN --role-session-name test`',
+      'export TEMP_ROLE',
+      'export AWS_ACCESS_KEY_ID=$(echo "${TEMP_ROLE}" | jq -r \'.Credentials.AccessKeyId\')',
+      'export AWS_SECRET_ACCESS_KEY=$(echo "${TEMP_ROLE}" | jq -r \'.Credentials.SecretAccessKey\')',
+      'export AWS_SESSION_TOKEN=$(echo "${TEMP_ROLE}" | jq -r \'.Credentials.SessionToken\')',
+    ];
   }
 }

--- a/packages/infra/infra-shared/src/stacks/ci/ciDocs.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciDocs.ts
@@ -4,9 +4,14 @@ import * as codebuild from 'aws-cdk-lib/aws-codebuild';
 import * as codepipeline from 'aws-cdk-lib/aws-codepipeline';
 import * as codepipelineActions from 'aws-cdk-lib/aws-codepipeline-actions';
 import * as iam from 'aws-cdk-lib/aws-iam';
-import { EnvConstructProps, ServiceCiConfig } from '@sb/infra-core';
+import {
+  EnvConstructProps,
+  PnpmWorkspaceFilters,
+  ServiceCiConfig,
+} from '@sb/infra-core';
 import { BootstrapStack } from '../bootstrap';
 import { EnvMainStack } from '../main';
+import { GlobalECR } from '../global/resources/globalECR';
 
 interface DocsCiConfigProps extends EnvConstructProps {
   inputArtifact: codepipeline.Artifact;
@@ -60,20 +65,21 @@ export class DocsCiConfig extends ServiceCiConfig {
   }
 
   private createBuildProject(props: DocsCiConfigProps) {
+    const preBuildCommands = [
+      ...this.getWorkspaceSetupCommands(PnpmWorkspaceFilters.DOCS),
+      this.getECRLoginCommand(),
+    ];
+    const baseImage = `${GlobalECR.getECRPublicCacheUrl()}/${
+      props.envSettings.dockerImages.backendBaseImage
+    }`;
+
     const project = new codebuild.Project(this, 'DocsBuildProject', {
       projectName: `${props.envSettings.projectEnvName}-build-docs`,
       buildSpec: codebuild.BuildSpec.fromObject({
         version: '0.2',
         phases: {
           pre_build: {
-            commands: [
-              'go install github.com/segmentio/chamber/v2@latest',
-              'npm i -g pnpm@^8.6.1',
-              `pnpm install \
-                --include-workspace-root \
-                --frozen-lockfile \
-                --filter=docs...`,
-            ],
+            commands: preBuildCommands,
           },
           build: { commands: ['pnpm nx run docs:build'] },
         },
@@ -95,6 +101,18 @@ export class DocsCiConfig extends ServiceCiConfig {
           type: codebuild.BuildEnvironmentVariableType.PLAINTEXT,
           value: props.envSettings.envStage,
         },
+        DOCKER_USERNAME: {
+          type: codebuild.BuildEnvironmentVariableType.SECRETS_MANAGER,
+          value: 'GlobalBuildSecrets:DOCKER_USERNAME',
+        },
+        DOCKER_PASSWORD: {
+          type: codebuild.BuildEnvironmentVariableType.SECRETS_MANAGER,
+          value: 'GlobalBuildSecrets:DOCKER_PASSWORD',
+        },
+        BACKEND_BASE_IMAGE: {
+          type: codebuild.BuildEnvironmentVariableType.PLAINTEXT,
+          value: baseImage,
+        },
       },
       cache: codebuild.Cache.local(codebuild.LocalCacheMode.DOCKER_LAYER),
     });
@@ -106,6 +124,10 @@ export class DocsCiConfig extends ServiceCiConfig {
     EnvMainStack.getIamPolicyStatementsForEnvParameters(
       props.envSettings
     ).forEach((statement) => project.addToRolePolicy(statement));
+
+    GlobalECR.getPublicECRIamPolicyStatements().forEach((statement) =>
+      project.addToRolePolicy(statement)
+    );
 
     return project;
   }
@@ -130,14 +152,7 @@ export class DocsCiConfig extends ServiceCiConfig {
         version: '0.2',
         phases: {
           pre_build: {
-            commands: [
-              'go install github.com/segmentio/chamber/v2@latest',
-              'npm i -g pnpm@^8.6.1',
-              `pnpm install \
-                --include-workspace-root \
-                --frozen-lockfile \
-                --filter=docs...`,
-            ],
+            commands: this.getWorkspaceSetupCommands(PnpmWorkspaceFilters.DOCS),
           },
           build: { commands: ['pnpm nx run docs:deploy'] },
         },

--- a/packages/infra/infra-shared/src/stacks/ci/ciUploadVersion.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciUploadVersion.ts
@@ -3,7 +3,11 @@ import * as codebuild from 'aws-cdk-lib/aws-codebuild';
 import * as codebuildActions from 'aws-cdk-lib/aws-codepipeline-actions';
 import * as codepipeline from 'aws-cdk-lib/aws-codepipeline';
 import * as iam from 'aws-cdk-lib/aws-iam';
-import { EnvConstructProps, ServiceCiConfig } from '@sb/infra-core';
+import {
+  EnvConstructProps,
+  PnpmWorkspaceFilters,
+  ServiceCiConfig,
+} from '@sb/infra-core';
 import { BootstrapStack } from '../bootstrap';
 import { EnvMainStack } from '../main';
 
@@ -48,15 +52,10 @@ export class UploadVersionCiConfig extends ServiceCiConfig {
         version: '0.2',
         phases: {
           pre_build: {
-            commands: [
-              'go install github.com/segmentio/chamber/v2@latest',
-              'npm i -g pnpm@^8.6.1',
-              `pnpm install \
-                --include-workspace-root \
-                --frozen-lockfile \
-                --filter=core \
-                --filter=tools`,
-            ],
+            commands: this.getWorkspaceSetupCommands(
+              PnpmWorkspaceFilters.CORE,
+              PnpmWorkspaceFilters.TOOLS
+            ),
           },
           build: {
             commands: [

--- a/packages/infra/infra-shared/src/stacks/ci/ciWebApp.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciWebApp.ts
@@ -4,7 +4,11 @@ import * as codebuild from 'aws-cdk-lib/aws-codebuild';
 import * as codepipelineActions from 'aws-cdk-lib/aws-codepipeline-actions';
 import * as codepipeline from 'aws-cdk-lib/aws-codepipeline';
 import * as iam from 'aws-cdk-lib/aws-iam';
-import { EnvConstructProps, ServiceCiConfig } from '@sb/infra-core';
+import {
+  EnvConstructProps,
+  PnpmWorkspaceFilters,
+  ServiceCiConfig,
+} from '@sb/infra-core';
 import { BootstrapStack } from '../bootstrap';
 import { EnvMainStack } from '../main';
 
@@ -76,14 +80,9 @@ export class WebappCiConfig extends ServiceCiConfig {
         version: '0.2',
         phases: {
           pre_build: {
-            commands: [
-              'go install github.com/segmentio/chamber/v2@latest',
-              'npm i -g pnpm@^8.6.1',
-              `pnpm install \
-                --include-workspace-root \
-                --frozen-lockfile \
-                --filter=webapp...`,
-            ],
+            commands: this.getWorkspaceSetupCommands(
+              PnpmWorkspaceFilters.WEBAPP
+            ),
           },
           build: {
             commands: [
@@ -146,14 +145,9 @@ export class WebappCiConfig extends ServiceCiConfig {
         version: '0.2',
         phases: {
           pre_build: {
-            commands: [
-              'go install github.com/segmentio/chamber/v2@latest',
-              'npm i -g pnpm@^8.6.1',
-              `pnpm install \
-                --include-workspace-root \
-                --frozen-lockfile \
-                --filter=webapp...`,
-            ],
+            commands: this.getWorkspaceSetupCommands(
+              PnpmWorkspaceFilters.WEBAPP
+            ),
           },
           build: { commands: ['pnpm nx run webapp:deploy'] },
         },

--- a/packages/infra/infra-shared/src/stacks/ci/e2eTests.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/e2eTests.ts
@@ -4,7 +4,12 @@ import * as codepipelineActions from 'aws-cdk-lib/aws-codepipeline-actions';
 import * as codepipeline from 'aws-cdk-lib/aws-codepipeline';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as cc from 'aws-cdk-lib/aws-codecommit';
-import { EnvConstructProps, ServiceCiConfig } from '@sb/infra-core';
+import {
+  EnvConstructProps,
+  PnpmWorkspaceFilters,
+  ServiceCiConfig,
+} from '@sb/infra-core';
+import { GlobalECR } from '../global/resources/globalECR';
 import { BootstrapStack } from '../bootstrap';
 import { EnvMainStack } from '../main';
 
@@ -43,6 +48,15 @@ export class E2ETestsCiConfig extends ServiceCiConfig {
 
     const basicAuth = props.envSettings.appBasicAuth?.split(':');
 
+    const installCommands = this.getAssumeRoleCommands();
+    const preBuildCommands = [
+      ...this.getWorkspaceSetupCommands(PnpmWorkspaceFilters.E2E_TESTS),
+      this.getECRLoginCommand(),
+    ];
+    const baseImage = `${GlobalECR.getECRPublicCacheUrl()}/${
+      props.envSettings.dockerImages.e2eTestsBaseImage
+    }`;
+
     const project = new codebuild.Project(this, 'E2ETestsProject', {
       projectName: `${props.envSettings.projectEnvName}-e2e-tests`,
       source: codebuild.Source.codeCommit({ repository: props.codeRepository }),
@@ -50,23 +64,10 @@ export class E2ETestsCiConfig extends ServiceCiConfig {
         version: '0.2',
         phases: {
           install: {
-            commands: [
-              'TEMP_ROLE=`aws sts assume-role --role-arn $ASSUME_ROLE_ARN --role-session-name test`',
-              'export TEMP_ROLE',
-              'export AWS_ACCESS_KEY_ID=$(echo "${TEMP_ROLE}" | jq -r \'.Credentials.AccessKeyId\')',
-              'export AWS_SECRET_ACCESS_KEY=$(echo "${TEMP_ROLE}" | jq -r \'.Credentials.SecretAccessKey\')',
-              'export AWS_SESSION_TOKEN=$(echo "${TEMP_ROLE}" | jq -r \'.Credentials.SessionToken\')',
-            ],
+            commands: installCommands,
           },
           pre_build: {
-            commands: [
-              'go install github.com/segmentio/chamber/v2@latest',
-              'npm i -g pnpm@^8.6.1',
-              `pnpm install \
-                --include-workspace-root \
-                --frozen-lockfile \
-                --filter=e2e-tests^...`,
-            ],
+            commands: preBuildCommands,
           },
           build: { commands: ['pnpm nx run e2e-tests:test'] },
         },
@@ -83,6 +84,10 @@ export class E2ETestsCiConfig extends ServiceCiConfig {
         ASSUME_ROLE_ARN: {
           type: codebuild.BuildEnvironmentVariableType.PLAINTEXT,
           value: dockerAssumeRole.roleArn,
+        },
+        E2E_TESTS_BASE_IMAGE: {
+          type: codebuild.BuildEnvironmentVariableType.PLAINTEXT,
+          value: baseImage,
         },
         ...(basicAuth
           ? {
@@ -126,6 +131,10 @@ export class E2ETestsCiConfig extends ServiceCiConfig {
         actions: ['sts:AssumeRole'],
         resources: [dockerAssumeRole.roleArn],
       })
+    );
+
+    GlobalECR.getPublicECRIamPolicyStatements().forEach((statement) =>
+      project.addToRolePolicy(statement)
     );
 
     return project;

--- a/packages/infra/infra-shared/src/stacks/global/resources/globalECR.ts
+++ b/packages/infra/infra-shared/src/stacks/global/resources/globalECR.ts
@@ -1,15 +1,58 @@
 import { Construct } from 'constructs';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
-import {
-  EnvConstructProps,
-  EnvironmentSettings,
-} from '@sb/infra-core';
+import { EnvConstructProps, EnvironmentSettings } from '@sb/infra-core';
+import { Fn } from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
 
 export class GlobalECR extends Construct {
+  static ECRPublicRepositoryPrefix = 'ecr-public';
+  static ECRPublicCacheRuleUpstreamRegistryUrl = 'public.ecr.aws';
+
   backendRepository: ecr.Repository;
+  ecrPublicCacheRule: ecr.CfnPullThroughCacheRule;
 
   static getBackendRepositoryName(envSettings: EnvironmentSettings) {
     return `${envSettings.projectName}-backend`;
+  }
+
+  static getECRPublicCacheUrl() {
+    const registryId = Fn.ref('AWS::AccountId');
+    const region = Fn.ref('AWS::Region');
+
+    return `${registryId}.dkr.ecr.${region}.amazonaws.com/${GlobalECR.ECRPublicRepositoryPrefix}`;
+  }
+
+  static getPublicECRIamPolicyStatements() {
+    const registryId = Fn.ref('AWS::AccountId');
+    const region = Fn.ref('AWS::Region');
+
+    return [
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['ecr:BatchImportUpstreamImage', 'ecr:CreateRepository'],
+        resources: [
+          `arn:aws:ecr:${region}:${registryId}:repository/${GlobalECR.ECRPublicRepositoryPrefix}/*`,
+        ],
+      }),
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'ecr:GetAuthorizationToken',
+          'ecr:BatchCheckLayerAvailability',
+          'ecr:GetDownloadUrlForLayer',
+          'ecr:GetRepositoryPolicy',
+          'ecr:DescribeRepositories',
+          'ecr:ListImages',
+          'ecr:DescribeImages',
+          'ecr:BatchGetImage',
+          'ecr:GetLifecyclePolicy',
+          'ecr:GetLifecyclePolicyPreview',
+          'ecr:ListTagsForResource',
+          'ecr:DescribeImageScanFindings',
+        ],
+        resources: ['*'],
+      }),
+    ];
   }
 
   constructor(scope: Construct, id: string, props: EnvConstructProps) {
@@ -18,5 +61,13 @@ export class GlobalECR extends Construct {
     this.backendRepository = new ecr.Repository(this, 'ECRBackendRepository', {
       repositoryName: GlobalECR.getBackendRepositoryName(props.envSettings),
     });
+    this.ecrPublicCacheRule = new ecr.CfnPullThroughCacheRule(
+      this,
+      'ECRPublicCacheRule',
+      {
+        ecrRepositoryPrefix: GlobalECR.ECRPublicRepositoryPrefix,
+        upstreamRegistryUrl: GlobalECR.ECRPublicCacheRuleUpstreamRegistryUrl,
+      }
+    );
   }
 }

--- a/packages/workers/Dockerfile
+++ b/packages/workers/Dockerfile
@@ -1,10 +1,11 @@
+ARG WORKERS_BASE_IMAGE=python:3.9-slim-bullseye
 ##
 # Chamber installation stage
 ##
 
 FROM segment/chamber:2 AS chamber
 
-FROM python:3.9-slim-bullseye
+FROM $WORKERS_BASE_IMAGE
 
 ENV APP_PATH=/app
 ENV SRC_CORE_PATH=packages/internal/core


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines

### What kind of change does this PR introduce?

closes #204 

### What is the current behavior?

Inside CodePipeline, sometimes the deployment fails because of dockerhub 429 Too Many Requests error.

### What is the new behavior?

The official images (ex. python, cypress) are downloaded from public AWS ECR repo and pulled from cache subsequently.
