### PR TITLE
fix: Sync stripe's Product and Price before initialising subscriptions

### DIFF
--- a/packages/backend/scripts/run_local.sh
+++ b/packages/backend/scripts/run_local.sh
@@ -23,9 +23,10 @@ echo "LocalStack fixtures installed"
 python manage.py contentful_sync
 python manage.py migrate
 
-if (echo "$STRIPE_LIVE_SECRET_KEY" | grep "<CHANGE_ME>") && (echo "$STRIPE_TEST_SECRET_KEY" | grep "<CHANGE_ME>"); then
+if (echo "$STRIPE_LIVE_SECRET_KEY" | grep -q "<CHANGE_ME>") && (echo "$STRIPE_TEST_SECRET_KEY" | grep -q "<CHANGE_ME>"); then
     echo "Stripe initialization skipped"
 else
+    python manage.py djstripe_sync_models Product Price
     python manage.py init_subscriptions
     echo "Stripe initialized"
 fi


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines

### What kind of change does this PR introduce?

closes #224 

### What is the current behavior?

Stripe's subscriptions are initialised without Products and Prices sync first, which causes to create duplicates with a fresh database instance.

### What is the new behavior?

Products and Prices are synced before running `init_subscriptions` command, which prevents creating duplicates with a fresh db instance and subscription plans already present in the stripe account.
