### PR TITLE
feat: Replace flake8 with ruff inside workers

### DIFF
--- a/packages/workers/dao/db/connection.py
+++ b/packages/workers/dao/db/connection.py
@@ -7,15 +7,14 @@ db_url = None
 db = None
 
 if settings.DB_CONNECTION is not None:
-    db_url = url.URL.create(
-        **{
-            'drivername': settings.DB_CONNECTION['engine'],
-            'host': settings.DB_CONNECTION['host'],
-            'port': settings.DB_CONNECTION['port'],
-            'username': settings.DB_CONNECTION['username'],
-            'password': settings.DB_CONNECTION['password'],
-            'database': settings.DB_CONNECTION['dbname'],
-        }
-    )
+    url_params = {
+        'drivername': settings.DB_CONNECTION['engine'],
+        'host': settings.DB_CONNECTION['host'],
+        'port': settings.DB_CONNECTION['port'],
+        'username': settings.DB_CONNECTION['username'],
+        'password': settings.DB_CONNECTION['password'],
+        'database': settings.DB_CONNECTION['dbname'],
+    }
+    db_url = url.URL.create(**url_params)
 
     db = create_engine(db_url)

--- a/packages/workers/pdm.lock
+++ b/packages/workers/pdm.lock
@@ -148,17 +148,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flake8"
-version = "6.0.0"
-requires_python = ">=3.8.1"
-summary = "the modular source code checker: pep8 pyflakes and co"
-dependencies = [
-    "mccabe<0.8.0,>=0.7.0",
-    "pycodestyle<2.11.0,>=2.10.0",
-    "pyflakes<3.1.0,>=3.0.0",
-]
-
-[[package]]
 name = "freezegun"
 version = "1.2.2"
 requires_python = ">=3.6"
@@ -227,12 +216,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mccabe"
-version = "0.7.0"
-requires_python = ">=3.6"
-summary = "McCabe checker, plugin for flake8"
-
-[[package]]
 name = "moto"
 version = "4.1.1"
 requires_python = ">=3.7"
@@ -288,12 +271,6 @@ requires_python = ">=3.6"
 summary = "psycopg2 - Python-PostgreSQL Database Adapter"
 
 [[package]]
-name = "pycodestyle"
-version = "2.10.0"
-requires_python = ">=3.6"
-summary = "Python style guide checker"
-
-[[package]]
 name = "pycparser"
 version = "2.21"
 requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
@@ -307,12 +284,6 @@ summary = "Data validation and settings management using python type hints"
 dependencies = [
     "typing-extensions>=4.2.0",
 ]
-
-[[package]]
-name = "pyflakes"
-version = "3.0.1"
-requires_python = ">=3.6"
-summary = "passive checker of Python programs"
 
 [[package]]
 name = "pyjwt"
@@ -428,6 +399,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.0.274"
+requires_python = ">=3.7"
+summary = "An extremely fast Python linter, written in Rust."
+
+[[package]]
 name = "s3transfer"
 version = "0.6.0"
 requires_python = ">= 3.7"
@@ -492,8 +469,10 @@ requires_python = ">=3.4"
 summary = "Makes working with XML feel like you are working with JSON"
 
 [metadata]
-lock_version = "4.1"
-content_hash = "sha256:73e343b3256a30fbcff24e2e184c7c95dbfca8586433a9396b3ab6bf22d82832"
+lock_version = "4.2"
+cross_platform = true
+groups = ["default", "dev"]
+content_hash = "sha256:c01bcc2015894501a680e9980e7c4b5f7106e17501a5bfd0a1e85a919f1de7ca"
 
 [metadata.files]
 "attrs 22.1.0" = [
@@ -700,10 +679,6 @@ content_hash = "sha256:73e343b3256a30fbcff24e2e184c7c95dbfca8586433a9396b3ab6bf2
     {url = "https://files.pythonhosted.org/packages/60/78/d6a75e9b58f22659c9e46b24a7d601c2d738b719b53b542f14248ab6177d/Faker-13.15.1.tar.gz", hash = "sha256:7c3f8ee807d3916415568169a172bf0893ea9cc3371ab55e4e5f5170d2185bea"},
     {url = "https://files.pythonhosted.org/packages/d0/5a/19a00c34c49a9cd6b584684bac18985c792c1b82f8ff9300ea5182e02201/Faker-13.15.1-py3-none-any.whl", hash = "sha256:172e45220b7a46743f4fb58cf380adb306d5c3ab1c0b0d97062508474cec5ff8"},
 ]
-"flake8 6.0.0" = [
-    {url = "https://files.pythonhosted.org/packages/66/53/3ad4a3b74d609b3b9008a10075c40e7c8909eae60af53623c3888f7a529a/flake8-6.0.0.tar.gz", hash = "sha256:c61007e76655af75e6785a931f452915b371dc48f56efd765247c8fe68f2b181"},
-    {url = "https://files.pythonhosted.org/packages/d9/6a/bb0122ebe280476c924470779d2595f1403878cafe3c8a343ac56a5a9c0e/flake8-6.0.0-py2.py3-none-any.whl", hash = "sha256:3833794e27ff64ea4e9cf5d410082a8b97ff1a06c16aa3d2027339cd0f1195c7"},
-]
 "freezegun 1.2.2" = [
     {url = "https://files.pythonhosted.org/packages/1d/97/002ac49ec52858538b4aa6f6831f83c2af562c17340bdf6043be695f39ac/freezegun-1.2.2.tar.gz", hash = "sha256:cd22d1ba06941384410cd967d8a99d5ae2442f57dfafeff2fda5de8dc5c05446"},
     {url = "https://files.pythonhosted.org/packages/50/cd/ba1c8319c002727ccfa03049127218d1767232a77219924d03ba170e0601/freezegun-1.2.2-py3-none-any.whl", hash = "sha256:ea1b963b993cb9ea195adbd893a48d573fda951b0da64f60883d7e988b606c9f"},
@@ -835,10 +810,6 @@ content_hash = "sha256:73e343b3256a30fbcff24e2e184c7c95dbfca8586433a9396b3ab6bf2
     {url = "https://files.pythonhosted.org/packages/19/35/07a369156dc53384c381c9b2b9fa63c35478b2289b47b4ee7d81418637e5/marshmallow-3.17.0-py3-none-any.whl", hash = "sha256:00040ab5ea0c608e8787137627a8efae97fabd60552a05dc889c888f814e75eb"},
     {url = "https://files.pythonhosted.org/packages/50/23/cd717da7c1a78845b3127ba053c2a561d1193b8a0392ca1b4a4e61a5d7d4/marshmallow-3.17.0.tar.gz", hash = "sha256:635fb65a3285a31a30f276f30e958070f5214c7196202caa5c7ecf28f5274bc7"},
 ]
-"mccabe 0.7.0" = [
-    {url = "https://files.pythonhosted.org/packages/27/1a/1f68f9ba0c207934b35b86a8ca3aad8395a3d6dd7921c0686e23853ff5a9/mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
-    {url = "https://files.pythonhosted.org/packages/e7/ff/0ffefdcac38932a54d2b5eed4e0ba8a408f215002cd178ad1df0f2806ff8/mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
-]
 "moto 4.1.1" = [
     {url = "https://files.pythonhosted.org/packages/90/28/9bca5de096abcb2f3dbc33aae389c66aa8ca9e72282b4ff846feecd59df5/moto-4.1.1.tar.gz", hash = "sha256:6c45755e541a85e5382f809c75255d0b6335de334e7e8eb717f8fdc755830a8c"},
     {url = "https://files.pythonhosted.org/packages/aa/19/37b2d52c0088ac13ec221e5e37d473b3f3f76ec270b359e21d73de35c89f/moto-4.1.1-py2.py3-none-any.whl", hash = "sha256:c4df7ae86f7cdd8ffcb2fcf55a45a7ab9f854ec631f1b9c82b1f47ae8c033326"},
@@ -936,10 +907,6 @@ content_hash = "sha256:73e343b3256a30fbcff24e2e184c7c95dbfca8586433a9396b3ab6bf2
     {url = "https://files.pythonhosted.org/packages/ff/43/8d0c3d17ccc43893ac6bc0bd4211facaa664fcb97a25524a6203f59dbaab/psycopg2_binary-2.9.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9ffdc51001136b699f9563b1c74cc1f8c07f66ef7219beb6417a4c8aaa896c28"},
     {url = "https://files.pythonhosted.org/packages/ff/e2/e82829bbf209d9fa4ca5df95b244eab30ee170d6c3ba2bf8f0a8a02c64bf/psycopg2_binary-2.9.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:c5e65c6ac0ae4bf5bef1667029f81010b6017795dcb817ba5c7b8a8d61fab76f"},
 ]
-"pycodestyle 2.10.0" = [
-    {url = "https://files.pythonhosted.org/packages/06/6b/5ca0d12ef7dcf7d20dfa35287d02297f3e0f9e515da5183654c03a9636ce/pycodestyle-2.10.0.tar.gz", hash = "sha256:347187bdb476329d98f695c213d7295a846d1152ff4fe9bacb8a9590b8ee7053"},
-    {url = "https://files.pythonhosted.org/packages/a2/54/001fdc0d69e8d0bb86c3423a6fa6dfada8cc26317c2635ab543e9ac411bd/pycodestyle-2.10.0-py2.py3-none-any.whl", hash = "sha256:8a4eaf0d0495c7395bdab3589ac2db602797d76207242c17d470186815706610"},
-]
 "pycparser 2.21" = [
     {url = "https://files.pythonhosted.org/packages/5e/0b/95d387f5f4433cb0f53ff7ad859bd2c6051051cebbb564f139a999ab46de/pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
     {url = "https://files.pythonhosted.org/packages/62/d5/5f610ebe421e85889f2e55e33b7f9a6795bd982198517d912eb1c76e1a53/pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
@@ -981,10 +948,6 @@ content_hash = "sha256:73e343b3256a30fbcff24e2e184c7c95dbfca8586433a9396b3ab6bf2
     {url = "https://files.pythonhosted.org/packages/ea/45/86ec3475f45f02858808643f38700788c64bfef0896566936dc33a78d4ba/pydantic-1.10.4-cp39-cp39-win_amd64.whl", hash = "sha256:9cbdc268a62d9a98c56e2452d6c41c0263d64a2009aac69246486f01b4f594c4"},
     {url = "https://files.pythonhosted.org/packages/ec/f2/c136265b246eb0411b293763e1b5e18a22de2d8d6a084e5c3d7b9e6e796e/pydantic-1.10.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:39f4a73e5342b25c2959529f07f026ef58147249f9b7431e1ba8414a36761f53"},
     {url = "https://files.pythonhosted.org/packages/f4/09/6efdaefc6e967f03af3ae3d5e63575036598eb0c740a43a69a77be054a5f/pydantic-1.10.4-cp38-cp38-win_amd64.whl", hash = "sha256:4b05697738e7d2040696b0a66d9f0a10bec0efa1883ca75ee9e55baf511909d6"},
-]
-"pyflakes 3.0.1" = [
-    {url = "https://files.pythonhosted.org/packages/af/4c/b1c7008aa7788b3e26c06c60aa18da7d3aa1f00e344aa3f18ac92768854b/pyflakes-3.0.1-py2.py3-none-any.whl", hash = "sha256:ec55bf7fe21fff7f1ad2f7da62363d749e2a470500eab1b555334b67aa1ef8cf"},
-    {url = "https://files.pythonhosted.org/packages/f2/51/506ddcfab10d708e8460554cc1cf37c727a6a2cccbad8dfe57766cfce33c/pyflakes-3.0.1.tar.gz", hash = "sha256:ec8b276a6b60bd80defed25add7e439881c19e64850afd9b346283d4165fd0fd"},
 ]
 "pyjwt 2.6.0" = [
     {url = "https://files.pythonhosted.org/packages/40/46/505f0dd53c14096f01922bf93a7abb4e40e29a06f858abbaa791e6954324/PyJWT-2.6.0-py3-none-any.whl", hash = "sha256:d83c3d892a77bbb74d3e1a2cfa90afaadb60945205d1095d9221f04466f64c14"},
@@ -1033,6 +996,25 @@ content_hash = "sha256:73e343b3256a30fbcff24e2e184c7c95dbfca8586433a9396b3ab6bf2
 "responses 0.21.0" = [
     {url = "https://files.pythonhosted.org/packages/6d/db/b949a6bf2a75c64caea0a6b39d05e433aa2e51bea78ae9d5dda1110b31a5/responses-0.21.0.tar.gz", hash = "sha256:b82502eb5f09a0289d8e209e7bad71ef3978334f56d09b444253d5ad67bf5253"},
     {url = "https://files.pythonhosted.org/packages/bb/ad/fdd56219f0e320293c513ef0b3cdd018802a1bcfdb29ed9bc0c3bcb97f31/responses-0.21.0-py3-none-any.whl", hash = "sha256:2dcc863ba63963c0c3d9ee3fa9507cbe36b7d7b0fccb4f0bdfd9e96c539b1487"},
+]
+"ruff 0.0.274" = [
+    {url = "https://files.pythonhosted.org/packages/07/59/7b043efe280a7f6815c87fda4bf1e43e51c87b181f3b461bd761e29377f7/ruff-0.0.274-py3-none-macosx_10_9_x86_64.macosx_11_0_arm64.macosx_10_9_universal2.whl", hash = "sha256:fa9ad8776cb92f2739b8eee316cde841d6012d0eafbf06bae09166203ddf9bb8"},
+    {url = "https://files.pythonhosted.org/packages/18/26/3ee1c9717fa206318be9eb892b8326ac415f1a57952aa996fd7b88435126/ruff-0.0.274-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:044084f039a679e557240fefcf521e057941b163014cf969ac6d04620861e04a"},
+    {url = "https://files.pythonhosted.org/packages/30/ad/9dc28c29b8fbb390f2f08c5e2e961c9b2adf2d71549f78ac4f310f392b30/ruff-0.0.274-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dca36d651f88b4b24f17df5db54487057ce0ccd3599cbf38d237cf4d9f0d63c2"},
+    {url = "https://files.pythonhosted.org/packages/36/a2/7b226d7586607e3991646961b29a15d1f923fa8459f0015114c80394e82c/ruff-0.0.274-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:023cdc5e64b3f34244e12bd236ab412c6056061a2415d50fb862cab333b4ab7c"},
+    {url = "https://files.pythonhosted.org/packages/39/24/e60dfe0b610a13a716bb4fb574c6e4365c7404a16d8352b27edf6d6b1ee9/ruff-0.0.274-py3-none-macosx_10_7_x86_64.whl", hash = "sha256:6d7069157a5674be8090c7d89fa69dbb2478f333a80b1312d20ade2a870cca3e"},
+    {url = "https://files.pythonhosted.org/packages/73/31/3cc256943d29025793279244fd6837240382edd3c585f3b562a62b66deb6/ruff-0.0.274.tar.gz", hash = "sha256:c7e5f9deffbd02d8054f90b565a1106faee64e16cedf50f3aa05c14b59ff8727"},
+    {url = "https://files.pythonhosted.org/packages/7b/d1/029f18d1ad0456c01e23ec40c99c817be7593ce345711ec02683ff8092bf/ruff-0.0.274-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:86d943107f20fec924f56dc4933cefb0efbc1ec8b729e0a1afabac598c5586ca"},
+    {url = "https://files.pythonhosted.org/packages/7f/60/f8d4966112555805366ec2df37e3653d4d80adbc1b00bf4254dbbd9e340d/ruff-0.0.274-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:587130943110e9536018ce139158e2962d46623f379a4486aabfd525e9714b0e"},
+    {url = "https://files.pythonhosted.org/packages/84/7c/21841a330cd8e162ccc848d99e84a3cb27416cd7eb983cc17b082a6469ec/ruff-0.0.274-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b13e765b64487143f05e6ad6f624388b9ac5a6ff8657ff801091c9282de3ca52"},
+    {url = "https://files.pythonhosted.org/packages/b5/da/694e37da2604444f0c5a4dc5eb5cf23af02622d9b4638dc343997a84d3fd/ruff-0.0.274-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:34e71a06a4e27554ca2f1c2b1749a802e3e76cac41481cfc2cb86936c1e37d3c"},
+    {url = "https://files.pythonhosted.org/packages/b9/4b/25f1f00393db9a4d018039b7a39fca5164c6cb5b251caba7abd8ccd8f957/ruff-0.0.274-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6133fa856b230a0281197aeba3e89ce9595f9d8a7265113520ad259d416c9f4b"},
+    {url = "https://files.pythonhosted.org/packages/b9/d9/2dd3f535a211a73754c764212a52d7db70e9d55f9263a963b9b95e779dfe/ruff-0.0.274-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:461bda8c3a4c1591fd7a09960b86e2ffc9a59a1c42cf14d725077314c12b60b0"},
+    {url = "https://files.pythonhosted.org/packages/bd/7d/57ccbca1428cd4876bf68decfc465b2725ce5234da91fb4c4910443de0f5/ruff-0.0.274-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:5137f853fffa7352901038a1b5e36a97058380a554763e534aae9f6c0734fdab"},
+    {url = "https://files.pythonhosted.org/packages/c6/ec/fdd733bddd74cee9293cf235505f7e865d435306e24543ca590910f1260c/ruff-0.0.274-py3-none-win_amd64.whl", hash = "sha256:e80aa0c7e1347a96db846287695971925eb56760c019a7d66312fbca389a6800"},
+    {url = "https://files.pythonhosted.org/packages/cf/0b/bf76ae7566952fb0675537ea8730a567c416ba35cd23c95e70b3ea07139f/ruff-0.0.274-py3-none-win_arm64.whl", hash = "sha256:8b99ce776fc60fb938791f558b297e53ed634adeef1a7b84a33455924948c9af"},
+    {url = "https://files.pythonhosted.org/packages/e1/95/1debc53b970c97a991f15c01e6650e76b7e35c8cd4945b0a9a33ec2c53cc/ruff-0.0.274-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:39b80156ef57b33ab7bfc454b7c2678eaae07f43a7dcf2e7c058f72d87b49538"},
+    {url = "https://files.pythonhosted.org/packages/e6/4a/c09cde430f6aa48e98f0384d49e9612e4f22e2429f745e3e9eca30075f53/ruff-0.0.274-py3-none-win32.whl", hash = "sha256:09c87fa2c4f53bd63c1d8a35150683794b022f4f2fbd6ef2fe383ce21ab53fec"},
 ]
 "s3transfer 0.6.0" = [
     {url = "https://files.pythonhosted.org/packages/5e/c6/af903b5fab3f9b5b1e883f49a770066314c6dcceb589cf938d48c89556c1/s3transfer-0.6.0-py3-none-any.whl", hash = "sha256:06176b74f3a15f61f1b4f25a1fc29a4429040b7647133a463da8fa5bd28d5ecd"},

--- a/packages/workers/pyproject.toml
+++ b/packages/workers/pyproject.toml
@@ -4,6 +4,54 @@ skip-string-normalization = true
 exclude = "/(.git|.serverless|node_modules|data|__pypackages__)/"
 target-versions = "py39"
 
+[tool.ruff]
+select = ["E", "F", "B", "S", "A", "C40", "DJ", "PIE", "T20", "SIM", "PLR"]
+ignore = ["S101", "A003", "S105", "SIM105", "A002", "B904", "PLR0913"]
+
+# Allow autofix for all enabled rules (when `--fix`) is provided.
+fixable = ["E", "F", "C4", "PIE", "RET", "SIM", "PLR"]
+unfixable = ["B"]
+
+# Exclude a variety of commonly ignored directories.
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+    "migrations",
+    "libs",
+    "docs",
+    "data",
+    "test_*.py"
+]
+
+# Same as Black.
+line-length = 120
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+# Assume Python 3.9
+target-version = "py39"
+
+[tool.ruff.per-file-ignores]
+"__init__.py" = ["E402"]
 
 [tool.pdm]
 [[tool.pdm.source]]
@@ -14,7 +62,6 @@ verify_ssl = true
 [tool.pdm.dev-dependencies]
 dev = [
     "black~=22.12",
-    "flake8~=6.0",
     "moto~=4.1",
     "pytest~=7.2",
     "pytest-mock~=3.10",
@@ -22,10 +69,11 @@ dev = [
     "pytest-dotenv~=0.5",
     "python-dotenv~=0.21",
     "pytest-cov~=4.0",
+    "ruff>=0.0.261",
 ]
 [project]
 name = ""
-version = ""
+version = "1.0.0"
 description = ""
 authors = [
     {name = "", email = ""},
@@ -48,7 +96,6 @@ license = {text = "MIT"}
 [project.urls]
 homepage = ""
 
-[project.optional-dependencies]
 [build-system]
 requires = ["pdm-pep517"]
 build-backend = "pdm.pep517.api"

--- a/packages/workers/scripts/run_lint.sh
+++ b/packages/workers/scripts/run_lint.sh
@@ -4,13 +4,13 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-flake8
-
 if [ "${CI:-}" = "true" ]
 then
   black --config=pyproject.toml --check .
+  ruff check .
 else
-   black --config=pyproject.toml .
+  black --config=pyproject.toml .
+  ruff check --fix .
 fi
 
 pnpm nx lint:js

--- a/packages/workers/setup.py
+++ b/packages/workers/setup.py
@@ -11,17 +11,17 @@ from sqlalchemy.engine import url
 def create_test_database():
     env = Env()
     DB_CONNECTION = json.loads(env('DB_CONNECTION'))
+    db_url_params = {
+        'drivername': DB_CONNECTION['engine'],
+        'host': DB_CONNECTION['host'],
+        'port': DB_CONNECTION['port'],
+        'username': DB_CONNECTION['username'],
+        'password': DB_CONNECTION['password'],
+        'database': DB_CONNECTION['conndbname'],
+    }
+
     template_engine = create_engine(
-        url.URL.create(
-            **{
-                'drivername': DB_CONNECTION['engine'],
-                'host': DB_CONNECTION['host'],
-                'port': DB_CONNECTION['port'],
-                'username': DB_CONNECTION['username'],
-                'password': DB_CONNECTION['password'],
-                'database': DB_CONNECTION['conndbname'],
-            }
-        ),
+        url.URL.create(**db_url_params),
         echo=False,
     )
 
@@ -49,11 +49,9 @@ class CreateTestDB(Command):
 
     def initialize_options(self):
         """Defined as noop since this method must be implemented by all command classes."""
-        pass
 
     def finalize_options(self):
         """Defined as noop since this method must be implemented by all command classes."""
-        pass
 
     def run(self):
         load_dotenv(dotenv_path='.env.test', override=True)

--- a/packages/workers/userauth/constants.py
+++ b/packages/workers/userauth/constants.py
@@ -1,6 +1,11 @@
 from enum import Enum
 
 
+class ExportUserArchiveRootPaths(str, Enum):
+    LOCAL_ROOT = "tmp"
+    S3_ROOT = "exports"
+
+
 class UserEmails(str, Enum):
     USER_EXPORT = "USER_EXPORT"
     USER_EXPORT_ADMIN = "USER_EXPORT_ADMIN"

--- a/packages/workers/userauth/services/export.py
+++ b/packages/workers/userauth/services/export.py
@@ -11,6 +11,7 @@ from demo.services.export import CrudDemoItemDataExport, DocumentDemoItemFileExp
 from ..models import User
 from ..types import UserType
 from utils import hashid
+from ..constants import ExportUserArchiveRootPaths
 
 
 class UserDataExport(UserDataExportable):
@@ -60,7 +61,7 @@ class ExportUserArchive:
 
     def _export_user_archive_to_zip(self, user_data: dict, user_files: list[str]) -> str:
         s3 = boto3.client("s3", endpoint_url=settings.AWS_S3_ENDPOINT_URL)
-        archive_filename = f"/tmp/{self._user_id}.zip"
+        archive_filename = f"/{ExportUserArchiveRootPaths.LOCAL_ROOT.value}/{self._user_id}.zip"
 
         with zipfile.ZipFile(archive_filename, "w", zipfile.ZIP_DEFLATED) as zf:
             json_data_filename = f"{self._user_id}/{self._user_id}.json"
@@ -88,4 +89,4 @@ class ExportUserArchive:
 
     def _get_user_archive_obj_key(self) -> str:
         timestamp = datetime.datetime.now().strftime("%d-%m-%y_%H-%M-%S")
-        return f"exports/{self._user_id}_{timestamp}.zip"
+        return f"{ExportUserArchiveRootPaths.S3_ROOT.value}/{self._user_id}_{timestamp}.zip"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines

### What kind of change does this PR introduce?

closes #240 

### What is the current behavior?

Flake8 is used as a linter.

### What is the new behavior?

Flake8 is replaced with Ruff.