### PR TITLE
fix: Reference tools' env variables via AWS Parameter Store

### DIFF
--- a/packages/infra/infra-shared/src/stacks/ci/ciServerless.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciServerless.ts
@@ -260,6 +260,11 @@ export class ServerlessCiConfig extends ServiceCiConfig {
       project.addToRolePolicy(statement);
     });
 
+    GlobalECR.getPublicECRIamPolicyStatements().forEach((statement) => {
+      dockerAssumeRole.addToPolicy(statement);
+      project.addToRolePolicy(statement);
+    });
+
     project.addToRolePolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,

--- a/packages/internal/docs/docs/api-reference/env-files.mdx
+++ b/packages/internal/docs/docs/api-reference/env-files.mdx
@@ -63,12 +63,3 @@ following values:
 | --------- | ----------- | ------- |
 | `VERSION` |             | `test`  |
 
-### `.env.tools`
-
-| Name                             | Description                                                                       | Example              |
-| -------------------------------- | --------------------------------------------------------------------------------- | -------------------- |
-| `SB_TOOLS_ENABLED`               | Flag if tools are enabled                                                         | `true`               |
-| `SB_TOOLS_BASIC_AUTH`            | Basic Auth configuration of the version matrix service                            | `user:password`      |
-| `SB_TOOLS_HOSTED_ZONE_ID`        | Id of a AWS Route53 hosted zone of a domain used to host version matrix service   |                      |
-| `SB_TOOLS_HOSTED_ZONE_NAME`      | Name of a AWS Route53 hosted zone of a domain used to host version matrix service | `tools.example.com`  |
-| `SB_TOOLS_DOMAIN_VERSION_MATRIX` | A domain used to host version matrix tool                                         | `status.example.com` |

--- a/packages/internal/docs/docs/aws/deploy-to-aws/create-env-stage-in-repo.mdx
+++ b/packages/internal/docs/docs/aws/deploy-to-aws/create-env-stage-in-repo.mdx
@@ -101,6 +101,18 @@ If you want a deployment to be stared automatically when a commit is pushed to c
 chamber write qa SB_DEPLOY_BRANCHES master
 ```
 
+### \[Optional\] Set tools env variables
+
+To configure `tools` package env variables follow the example below.
+
+```shell
+chamber write qa SB_TOOLS_ENABLED <true/false>
+chamber write qa SB_TOOLS_BASIC_AUTH username:password
+chamber write qa SB_TOOLS_HOSTED_ZONE_ID XYZ
+chamber write qa SB_TOOLS_HOSTED_ZONE_NAME example.com
+chamber write qa SB_TOOLS_DOMAIN_VERSION_MATRIX status.example.com
+```
+
 ## Env variable validation
 
 You can look up the validator in `packages/internal/core/stage-env-validator.js`, which runs on every `nx` command that

--- a/packages/internal/docs/docs/working-with-sb/dev-tools/version-matrix.mdx
+++ b/packages/internal/docs/docs/working-with-sb/dev-tools/version-matrix.mdx
@@ -20,8 +20,8 @@ This tool displays a list of all environment stages (e.g. `dev`, `stage`, `prod`
 
 ## Configuration
 
-You can configure version matrix in `.env.tools` file in the root of your project. You can find the details in
-[`.env.tools` API Reference](../../api-reference/env-files#envtools).
+You can configure version matrix via AWS SSM Parameter Store. You can find the details in
+[\[Optional\] Set tools env variables](../../aws/deploy-to-aws/create-env-stage-in-repo#optional-set-tools-env-variables).
 
 
 ## Deployment

--- a/packages/internal/status-dashboard/package.json
+++ b/packages/internal/status-dashboard/package.json
@@ -3,8 +3,8 @@
   "version": "2.0.0-alpha.1",
   "private": true,
   "scripts": {
-    "deploy": "env-cmd -f ../../../.env.tools cdk deploy *StatusDashboardStack",
-    "diff": "env-cmd -f ../../../.env.tools cdk diff *StatusDashboardStack"
+    "deploy": "cdk deploy *StatusDashboardStack",
+    "diff": "cdk diff *StatusDashboardStack"
   },
   "dependencies": {
     "aws-sdk": "^2.703.0",

--- a/packages/internal/tools/project.json
+++ b/packages/internal/tools/project.json
@@ -65,7 +65,7 @@
       "options": {
         "color": true,
         "cwd": "packages/internal/tools",
-        "command": "env-cmd -f ../../../.env.tools ts-node --project tsconfig.lib.json ./src/upload-service-version"
+        "command": "ts-node --project tsconfig.lib.json ./src/upload-service-version"
       }
     },
     "upload-version": {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

closes #206 

### What is the current behavior?

Tools and status dashboard scripts are trying to reference removed `.env.tools`

### What is the new behavior?

Required env variables have been added to AWS SSM Parameter store and are retrieved via chamber.