### PR TITLE
fix: #280 Set `en` locale for Stripe elements instead of default `auto`

### DIFF
--- a/packages/webapp-libs/webapp-finances/src/components/stripe/stripePaymentForm/stripePaymentForm.stories.tsx
+++ b/packages/webapp-libs/webapp-finances/src/components/stripe/stripePaymentForm/stripePaymentForm.stories.tsx
@@ -16,7 +16,7 @@ import { StripePaymentForm, StripePaymentFormProps } from './stripePaymentForm.c
 
 const Template: StoryFn<StripePaymentFormProps> = (args: StripePaymentFormProps) => {
   return (
-    <Elements stripe={stripePromise}>
+    <Elements stripe={stripePromise} options={{ locale: 'en' }}>
       <StripePaymentForm {...args} />
     </Elements>
   );

--- a/packages/webapp-libs/webapp-finances/src/components/stripe/stripePaymentMethodSelector/stripePaymentMethodSelector.stories.tsx
+++ b/packages/webapp-libs/webapp-finances/src/components/stripe/stripePaymentMethodSelector/stripePaymentMethodSelector.stories.tsx
@@ -22,7 +22,7 @@ const Template: StoryFn<StripePaymentMethodSelectorProps<PaymentFormFields>> = (
   const { form } = useApiForm<PaymentFormFields>();
   return (
     <Form {...form}>
-      <Elements stripe={stripePromise}>
+      <Elements stripe={stripePromise} options={{ locale: 'en' }}>
         <StripePaymentMethodSelector {...args} control={form.control} />
       </Elements>
     </Form>

--- a/packages/webapp-libs/webapp-finances/src/routes/editPaymentMethod/editPaymentMethod.component.tsx
+++ b/packages/webapp-libs/webapp-finances/src/routes/editPaymentMethod/editPaymentMethod.component.tsx
@@ -31,7 +31,7 @@ export const EditPaymentMethod = () => {
         }
       />
 
-      <Elements stripe={stripePromise}>
+      <Elements stripe={stripePromise} options={{ locale: 'en' }}>
         <EditPaymentMethodForm
           onSuccess={() => {
             navigate(generateLocalePath(RoutesConfig.subscriptions.index));

--- a/packages/webapp-libs/webapp-finances/src/routes/paymentConfirm/paymentConfirm.component.tsx
+++ b/packages/webapp-libs/webapp-finances/src/routes/paymentConfirm/paymentConfirm.component.tsx
@@ -33,7 +33,7 @@ export const PaymentConfirm = () => {
         }
       />
 
-      <Elements stripe={stripePromise}>
+      <Elements stripe={stripePromise} options={{ locale: 'en' }}>
         <StripePaymentForm
           onSuccess={() => {
             navigate(generateLocalePath(CoreRoutesConfig.home));

--- a/packages/webapp-libs/webapp-finances/src/utils/storybook.tsx
+++ b/packages/webapp-libs/webapp-finances/src/utils/storybook.tsx
@@ -14,7 +14,7 @@ export const withActiveSubscriptionContext = (StoryComponent: Story) => {
         <Route
           index
           element={
-            <Elements stripe={stripePromise}>
+            <Elements stripe={stripePromise} options={{ locale: 'en' }}>
               <StoryComponent />
             </Elements>
           }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Set the `en` locale for Stripe elements instead of default `auto` 

### What is the current behavior?

Stripe detects locale automatically which cause mismatch between app locale.

### What is the new behavior?

Stripe will display errors in english instead of the machine locale.