### PR TITLE
fix: #309 Fix invalid version bump skipping main package.json file

### DIFF
--- a/.versionrc.js
+++ b/.versionrc.js
@@ -1,6 +1,10 @@
 module.exports = {
   bumpFiles: [
     {
+      filename: './package.json',
+      type: 'json',
+    },
+    {
       filename: './packages/webapp/package.json',
       type: 'json',
     },


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines

### What kind of change does this PR introduce?

Closes #309

### What is the current behavior?

Main `package.json` is skipped from version bump when on `standard-version` call

### What is the new behavior?

It's updated as should ;)
