### PR TITLE
Fix: `extract-intl` script not working as expected

### DIFF
--- a/packages/internal/docs/docs/api-reference/webapp/commands.mdx
+++ b/packages/internal/docs/docs/api-reference/webapp/commands.mdx
@@ -130,3 +130,11 @@ variables for AWS environment. Find more about setting environment variables for
 This command should be called only after `make set-env ENV_STAGE=<STAGE_NAME>` command.
 
 :::
+
+---
+
+### `nx run extract-intl`
+
+It extracts all [`formatjs`](https://formatjs.io/) messages from the `webapp` and `webapp-libs` packages using
+[`formatjs extract`](https://formatjs.io/docs/getting-started/message-extraction/#extraction) command to
+`webapp-libs/webapp-core/src/translations/en.json` file.

--- a/packages/webapp-libs/webapp-contentful/src/routes/demoItems/demoItems.component.tsx
+++ b/packages/webapp-libs/webapp-contentful/src/routes/demoItems/demoItems.component.tsx
@@ -23,7 +23,7 @@ export const DemoItems = () => {
         subheader={
           <FormattedMessage
             defaultMessage="This demo page showcases a dynamic list of items, each managed by Contentful headless CMS. The list not only presents an array of items but also demonstrates how each item can be synchronized with our application's database. This synchronization enables the integration of the application's business logic with the content managed in Contentful. You can interact with the list by clicking the star icon next to each item."
-            id="Contentful Items / List header"
+            id="Contentful Items / List subheader"
           />
         }
       />

--- a/packages/webapp-libs/webapp-crud-demo/src/routes/crudDemoItem/addCrudDemoItem/addCrudDemoItem.component.tsx
+++ b/packages/webapp-libs/webapp-crud-demo/src/routes/crudDemoItem/addCrudDemoItem/addCrudDemoItem.component.tsx
@@ -33,7 +33,7 @@ export const AddCrudDemoItem = () => {
   const navigate = useNavigate();
 
   const successMessage = intl.formatMessage({
-    id: 'CrudDemoItem form / Success message',
+    id: 'CrudDemoItem form / AddCrudDemoItem / Success message',
     defaultMessage: '🎉 Item added successfully!',
   });
 

--- a/packages/webapp-libs/webapp-crud-demo/src/routes/crudDemoItem/crudDemoItemList/crudDemoItemListItem/crudDemoItemListItem.component.tsx
+++ b/packages/webapp-libs/webapp-crud-demo/src/routes/crudDemoItem/crudDemoItemList/crudDemoItemListItem/crudDemoItemListItem.component.tsx
@@ -26,7 +26,7 @@ export const CrudDemoItemListItem = ({ item }: CrudDemoItemListItemProps) => {
   const intl = useIntl();
 
   const successMessage = intl.formatMessage({
-    id: 'CrudDemoItem form / Success message',
+    id: 'CrudDemoItem form / Delete CrudDemoItem / Success message',
     defaultMessage: '🎉 Item deleted successfully!',
   });
 

--- a/packages/webapp-libs/webapp-crud-demo/src/routes/crudDemoItem/editCrudDemoItem/editCrudDemoItem.component.tsx
+++ b/packages/webapp-libs/webapp-crud-demo/src/routes/crudDemoItem/editCrudDemoItem/editCrudDemoItem.component.tsx
@@ -26,7 +26,7 @@ export const EditCrudDemoItem = () => {
   const intl = useIntl();
 
   const successMessage = intl.formatMessage({
-    id: 'CrudDemoItem form / Success message',
+    id: 'CrudDemoItem form / EditCrudDemoItem / Success message',
     defaultMessage: '🎉 Changes saved successfully!',
   });
 

--- a/packages/webapp-libs/webapp-documents/src/routes/documents/documents.component.tsx
+++ b/packages/webapp-libs/webapp-documents/src/routes/documents/documents.component.tsx
@@ -65,7 +65,7 @@ export const Documents = () => {
         subheader={
           <FormattedMessage
             defaultMessage="You can drag files to a specific area, to upload. Alternatively, you can also upload by selecting."
-            id="Finances / Stripe / Payment confirm / subheading"
+            id="Documents / subheading"
           />
         }
       />

--- a/packages/webapp/package.json
+++ b/packages/webapp/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "pnpm nx run build-with-env",
-    "extract-intl": "formatjs extract 'src/**/!(*.d).(js|jsx|ts|tsx)' --id-interpolation-pattern '[sha512:contenthash:base64:6]' --out-file src/translations/en.json --ignore src/tests/mocks/**",
+    "extract-intl": "formatjs extract 'src/**/!(*.d).(js|jsx|ts|tsx)' '../webapp-libs/*/src/**/!(*.d).(js|jsx|ts|tsx)' --id-interpolation-pattern '[sha512:contenthash:base64:6]' --out-file ../webapp-libs/webapp-core/src/translations/en.json --ignore src/tests/mocks/** --ignore ../webapp-libs/*src/tests/mocks/**",
     "lint": "pnpm run lint:js && pnpm run lint:css",
     "lint:css": "stylelint './src/**/*.ts'",
     "lint:js": "eslint .",


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features) - **still to be added!**

### What kind of change does this PR introduce?

Fixes #338 

### What is the current behavior?
It generates the file in the incorrect place (in the `webapp` instead of the `webapp-core`) and with incorrect content (it does not scan `webapp-libs` packages for the copy)

### What is the new behavior?
It generates the file with the correct contents in the correct place
