### PR TITLE
fix: Increase memory limit for backend ECS task

### DIFF
--- a/packages/backend/infra/stacks/api/stack.ts
+++ b/packages/backend/infra/stacks/api/stack.ts
@@ -96,7 +96,7 @@ export class ApiStack extends Stack {
         serviceName: getApiServiceName(props.envSettings),
         cluster: resources.mainCluster,
         cpu: 512,
-        memoryLimitMiB: 1024,
+        memoryLimitMiB: 2048,
         desiredCount: 1,
         taskRole,
         taskImageOptions: [


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines

### What kind of change does this PR introduce?
Increases memory limit for the backend ECS task

### What is the current behavior?
There is an issue with the our of memory for the task causing it to constantly restart and create new task on ECS. Additionally there might be an issue with the deployment which gets an timeout error.
