### PR TITLE
fix: Fix API deployment issues on a small ECS task

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -17,7 +17,7 @@ ENV PIP_NO_CACHE_DIR off
 RUN apt-get update && apt-get install -y gcc postgresql-client ca-certificates jq \
   && update-ca-certificates \
   && pip install --upgrade pip \
-  && pip install --no-cache-dir setuptools pdm~=2.5.2 gunicorn awscli
+  && pip install --no-cache-dir setuptools pdm~=2.5.2 awscli
 
 
 COPY --from=chamber /chamber /bin/chamber

--- a/packages/backend/Makefile
+++ b/packages/backend/Makefile
@@ -57,5 +57,5 @@ secrets:
 	$(MAKE) -C $(PROJECT_ROOT_DIR) secrets-editor SERVICE_NAME=backend
 
 remote-shell:
-	./scripts/execute_remote.sh
+	chamber exec $(ENV_STAGE) -- ./scripts/execute_remote.sh
 

--- a/packages/backend/config/settings.py
+++ b/packages/backend/config/settings.py
@@ -70,6 +70,7 @@ SILENCED_SYSTEM_CHECKS = []  # default django value
 MIDDLEWARE = [
     #  HealthCheckMiddleware needs to be before the HostsRequestMiddleware
     "common.middleware.HealthCheckMiddleware",
+    "aws_xray_sdk.ext.django.middleware.XRayMiddleware",
     "common.middleware.ManageCookiesMiddleware",
     "common.middleware.SetAuthTokenCookieMiddleware",
     "django_hosts.middleware.HostsRequestMiddleware",

--- a/packages/backend/config/settings.py
+++ b/packages/backend/config/settings.py
@@ -70,7 +70,6 @@ SILENCED_SYSTEM_CHECKS = []  # default django value
 MIDDLEWARE = [
     #  HealthCheckMiddleware needs to be before the HostsRequestMiddleware
     "common.middleware.HealthCheckMiddleware",
-    "aws_xray_sdk.ext.django.middleware.XRayMiddleware",
     "common.middleware.ManageCookiesMiddleware",
     "common.middleware.SetAuthTokenCookieMiddleware",
     "django_hosts.middleware.HostsRequestMiddleware",

--- a/packages/backend/gunicorn.py
+++ b/packages/backend/gunicorn.py
@@ -2,8 +2,19 @@
 import logging
 from multiprocessing import cpu_count
 
+import environ
+
+env = environ.Env(
+    # set casting, default value
+    DJANGO_DEBUG=(bool, False)
+)
+
+DEBUG = env("DJANGO_DEBUG")
+
 
 def max_workers():
+    if DEBUG:
+        return 2
     return cpu_count() * 2 + 1
 
 

--- a/packages/backend/infra/stacks/api/stack.ts
+++ b/packages/backend/infra/stacks/api/stack.ts
@@ -1,4 +1,4 @@
-import { App, Fn, Stack, StackProps } from 'aws-cdk-lib';
+import {App, Duration, Fn, Stack, StackProps} from 'aws-cdk-lib';
 import * as ecs from 'aws-cdk-lib/aws-ecs';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import * as sm from 'aws-cdk-lib/aws-secretsmanager';
@@ -94,14 +94,20 @@ export class ApiStack extends Stack {
       {
         securityGroup: resources.fargateContainerSecurityGroup,
         serviceName: getApiServiceName(props.envSettings),
+        healthCheckGracePeriod: Duration.minutes(2),
         cluster: resources.mainCluster,
         cpu: 512,
-        memoryLimitMiB: 2048,
+        memoryLimitMiB: 1024,
         desiredCount: 1,
         taskRole,
         taskImageOptions: [
           {
             containerName: 'backend',
+            command:  [
+              "sh",
+              "-c",
+              "/bin/chamber exec $CHAMBER_SERVICE_NAME -- ./scripts/run.sh",
+            ],
             image: ecs.ContainerImage.fromEcrRepository(
               resources.backendRepository,
               envSettings.version

--- a/packages/backend/pdm.lock
+++ b/packages/backend/pdm.lock
@@ -520,6 +520,15 @@ requires_python = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 summary = "Lightweight in-process concurrent programming"
 
 [[package]]
+name = "gunicorn"
+version = "21.2.0"
+requires_python = ">=3.5"
+summary = "WSGI HTTP Server for UNIX"
+dependencies = [
+    "packaging",
+]
+
+[[package]]
 name = "hashids"
 version = "1.3.1"
 requires_python = ">=2.7"
@@ -1315,7 +1324,7 @@ dependencies = [
 [metadata]
 lock_version = "4.2"
 groups = ["default", "dev"]
-content_hash = "sha256:6c6def2593b67c68f2b77ce8f286a15e1acdc2fe15f1ed690aa59a3fa1439763"
+content_hash = "sha256:cf9ce847e6db798e36da7a5ca49c7ce6eb1c96cfb11d80bfab2394df54e828df"
 
 [metadata.files]
 "aiohttp 3.8.4" = [
@@ -1958,6 +1967,10 @@ content_hash = "sha256:6c6def2593b67c68f2b77ce8f286a15e1acdc2fe15f1ed690aa59a3fa
     {url = "https://files.pythonhosted.org/packages/e9/f3/d020c777e22c284199b6771c71907c923d9c2cf84bca8612077333d3ded6/greenlet-2.0.1-cp35-cp35m-macosx_10_14_x86_64.whl", hash = "sha256:2d0bac0385d2b43a7bd1d651621a4e0f1380abc63d6fb1012213a401cbd5bf8f"},
     {url = "https://files.pythonhosted.org/packages/fd/6a/f07b0028baff9bca61ecfcd9ee021e7e33369da8094f00eff409f2ff32be/greenlet-2.0.1.tar.gz", hash = "sha256:42e602564460da0e8ee67cb6d7236363ee5e131aa15943b6670e44e5c2ed0f67"},
     {url = "https://files.pythonhosted.org/packages/ff/ab/31c5327752c3381a9d3b2599245f4c2c21e9f3c73039fa4f34725562a7dd/greenlet-2.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:5067920de254f1a2dee8d3d9d7e4e03718e8fd2d2d9db962c8c9fa781ae82a39"},
+]
+"gunicorn 21.2.0" = [
+    {url = "https://files.pythonhosted.org/packages/06/89/acd9879fa6a5309b4bf16a5a8855f1e58f26d38e0c18ede9b3a70996b021/gunicorn-21.2.0.tar.gz", hash = "sha256:88ec8bff1d634f98e61b9f65bc4bf3cd918a90806c6f5c48bc5603849ec81033"},
+    {url = "https://files.pythonhosted.org/packages/0e/2a/c3a878eccb100ccddf45c50b6b8db8cf3301a6adede6e31d48e8531cab13/gunicorn-21.2.0-py3-none-any.whl", hash = "sha256:3213aa5e8c24949e792bcacfc176fef362e7aac80b76c56f6b5122bf350722f0"},
 ]
 "hashids 1.3.1" = [
     {url = "https://files.pythonhosted.org/packages/26/a2/6f38b1de47b41ad0420047ad03b0b8cd5d6572271a3e9c2ab70e373fe63a/hashids-1.3.1.tar.gz", hash = "sha256:6c3dc775e65efc2ce2c157a65acb776d634cb814598f406469abef00ae3f635c"},

--- a/packages/backend/project.json
+++ b/packages/backend/project.json
@@ -50,6 +50,31 @@
       },
       "dependsOn": ["compose-build-image"]
     },
+    "deploy:api": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "packages/backend",
+        "color": true,
+        "commands": [
+          "pnpm nx cdk:deploy:api",
+          "pnpm nx run tools:upload-service-version api \"url=https://${SB_DOMAIN_API}\""
+        ],
+        "parallel": false
+      }
+    },
+    "deploy:migrations": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "packages/backend",
+        "color": true,
+        "commands": [
+          "pnpm nx cdk:deploy:migrations",
+          "pnpm nx run trigger-migrations-job",
+          "pnpm nx run tools:upload-service-version migrations"
+        ],
+        "parallel": false
+      }
+    },
     "deploy": {
       "executor": "nx:run-commands",
       "options": {
@@ -57,23 +82,6 @@
         "color": true,
         "commands": ["nx cdk:deploy:api", "nx cdk:deploy:migrations"],
         "parallel": false
-      },
-      "configurations": {
-        "api": {
-          "commands": [
-            "pnpm nx cdk:deploy:api",
-            "pnpm nx run tools:upload-service-version api \"url=https://${SB_DOMAIN_API}\""
-          ],
-          "parallel": false
-        },
-        "migrations": {
-          "commands": [
-            "pnpm nx cdk:deploy:migrations",
-            "pnpm nx run trigger-migrations-job",
-            "pnpm nx run tools:upload-service-version migrations"
-          ],
-          "parallel": false
-        }
       }
     }
   },

--- a/packages/backend/pyproject.toml
+++ b/packages/backend/pyproject.toml
@@ -113,7 +113,8 @@ dependencies = [
     "pyotp>=2.8.0",
     "openai>=0.27.2",
     "pydantic>=1.10.7",
-    "pyyaml>=6.0.0"
+    "pyyaml>=6.0.0",
+    "gunicorn==21.2.0",
 ]
 requires-python = "~=3.11.0"
 license = {text = "MIT"}

--- a/packages/backend/scripts/execute_remote.sh
+++ b/packages/backend/scripts/execute_remote.sh
@@ -13,20 +13,6 @@ then
    exit 1
 fi
 
-ENV_FILE="../../.env"
-ENV_STAGE_FILE="${ENV_FILE}.${ENV_STAGE}"
-
-if [ ! -f "$ENV_FILE" ]; then
-  echo "$ENV_FILE cannot be found"
-  exit 1
-elif [ ! -f "$ENV_STAGE_FILE" ]; then
-  echo "$ENV_STAGE_FILE cannot be found"
-  exit 1
-else
-  export $(echo $(cat "$ENV_FILE" | sed 's/#.*//g'| xargs) | envsubst)
-  export $(echo $(cat "$ENV_STAGE_FILE" | sed 's/#.*//g'| xargs) | envsubst)
-fi
-
 PROJECT_ENV_NAME=${PROJECT_NAME}-${ENV_STAGE}
 
 CLUSTER_NAME="${PROJECT_ENV_NAME}-main"
@@ -41,4 +27,4 @@ aws ecs execute-command \
   --region "${AWS_DEFAULT_REGION//\"/}" \
   --task "$TASK_ARN" \
   --container backend \
-  --command "/bin/chamber exec ${CHAMBER_SERVICE_NAME} -- /bin/bash" --interactive
+  --command "/bin/bash" --interactive

--- a/packages/backend/scripts/run.sh
+++ b/packages/backend/scripts/run.sh
@@ -3,4 +3,4 @@ set -e
 
 echo Starting app server...
 
-gunicorn -c gunicorn.py config.wsgi:application
+pdm run gunicorn -c gunicorn.py config.wsgi:application

--- a/packages/infra/infra-core/src/lib/patterns/applicationMultipleTargetGroupsFargateServiceBase.ts
+++ b/packages/infra/infra-core/src/lib/patterns/applicationMultipleTargetGroupsFargateServiceBase.ts
@@ -192,6 +192,8 @@ export interface ApplicationLoadBalancedTaskImageProps {
    * @default - No labels.
    */
   readonly dockerLabels?: { [key: string]: string };
+
+  readonly command?: string[];
 }
 
 /**


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines

### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

During deployment, Backend API service is never able to register a new Task Definition, because it never passes health checks.

Seems that we're running too many workers (2*cpu count + 1) on too small of a task (512 vCPU) and they just don't have enough CPU to work with.

### What is the new behavior?

We limit number of workers when `DEBUG` is on. I think it's a better approach than increasing the size of the task to save costs. 

I also moved gunicorn dependency to pytoml file.

### Does this PR introduce a breaking change?

no

