### PR TITLE
fix: allow running nx run webapp:graphql:download-schema

### DIFF
--- a/packages/webapp-libs/webapp-contentful/scripts/download-graphql-schema.sh
+++ b/packages/webapp-libs/webapp-contentful/scripts/download-graphql-schema.sh
@@ -2,6 +2,21 @@
 
 export $(egrep -v '^#' .env | xargs)
 
+if [ "$VITE_CONTENTFUL_SPACE" == "<CHANGE_ME>" ]; then
+    echo "VITE_CONTENTFUL_SPACE has not been set. Skipping..."
+    exit 0
+fi
+
+if [ "$VITE_CONTENTFUL_ENV" == "<CHANGE_ME>" ]; then
+    echo "VITE_CONTENTFUL_ENV has not been set. Skipping..."
+    exit 0
+fi
+
+if [ "$VITE_CONTENTFUL_TOKEN" == "<CHANGE_ME>" ]; then
+    echo "VITE_CONTENTFUL_TOKEN has not been set. Skipping..."
+    exit 0
+fi
+
 CONTENTFUL_URL="https://graphql.contentful.com/content/v1/spaces/$VITE_CONTENTFUL_SPACE/environments/$VITE_CONTENTFUL_ENV?access_token=$VITE_CONTENTFUL_TOKEN"
 
 rm  -f ./src/contentful/__generated/types.ts

--- a/packages/webapp-libs/webapp-contentful/scripts/download-graphql-schema.sh
+++ b/packages/webapp-libs/webapp-contentful/scripts/download-graphql-schema.sh
@@ -2,17 +2,17 @@
 
 export $(egrep -v '^#' .env | xargs)
 
-if [ "$VITE_CONTENTFUL_SPACE" == "<CHANGE_ME>" ]; then
+if [ -z "$VITE_CONTENTFUL_SPACE" ] || [ "$VITE_CONTENTFUL_SPACE" == "<CHANGE_ME>" ]; then
     echo "VITE_CONTENTFUL_SPACE has not been set. Skipping..."
     exit 0
 fi
 
-if [ "$VITE_CONTENTFUL_ENV" == "<CHANGE_ME>" ]; then
+if [ -z "$VITE_CONTENTFUL_ENV" ] || [ "$VITE_CONTENTFUL_ENV" == "<CHANGE_ME>" ]; then
     echo "VITE_CONTENTFUL_ENV has not been set. Skipping..."
     exit 0
 fi
 
-if [ "$VITE_CONTENTFUL_TOKEN" == "<CHANGE_ME>" ]; then
+if [ -z "$VITE_CONTENTFUL_TOKEN" ] || [ "$VITE_CONTENTFUL_TOKEN" == "<CHANGE_ME>" ]; then
     echo "VITE_CONTENTFUL_TOKEN has not been set. Skipping..."
     exit 0
 fi


### PR DESCRIPTION
if the contentful env vars are not set

### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

This is an improvement: it allows the developers to run `nx run webapp:graphql:download-schema` without specifying the environment variables for Contentful (usually such an integration will come later in the development process), and also some developers might not use Contentful at all.

### What is the current behavior?

Currently,  `nx run webapp:graphql:download-schema` cannot be run without Contentful environment variables

### What is the new behavior?

### Does this PR introduce a breaking change?

No braking change introduced.

### Other information:
I am not sure what kind of tests could be done for such a change.
I do not think this change requires doc update.
Please advise.
