### PR TITLE
fix: documentation error for form-with-mutation.mdx

### DIFF
--- a/packages/internal/docs/docs/working-with-sb/graphql/web-app/form-with-mutation.mdx
+++ b/packages/internal/docs/docs/working-with-sb/graphql/web-app/form-with-mutation.mdx
@@ -199,7 +199,7 @@ export const useCreateProductForm = () => {
 // highlight-start
   const [commitMutation] = useMutation(createProductMutation, {
     onError: (error) => {
-      setApolloGraphQLResponseErrors(error.graphQLErrors);
+      form.setApolloGraphQLResponseErrors(error.graphQLErrors);
     }
   });
 // highlight-end


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

This is a fix

### What is the current behavior?

the documentation was not correctly describing that the `setApolloGraphQLResponseErrors` method is a method of the `form` object. A new user to graphql (like me) would be wondering about how to use it.

### What is the new behavior?

Now the doc correctly describes how to use this `setApolloGraphQLResponseErrors` method

### Does this PR introduce a breaking change?

No braking chnage

### Other information:
