### PR TITLE
docs: Adjust documentation next links

### DIFF
--- a/packages/internal/docs/docs/aws/index.mdx
+++ b/packages/internal/docs/docs/aws/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: AWS
+pagination_next: null
 ---
 
 import DocCardList from '@theme/DocCardList';

--- a/packages/internal/docs/docs/getting-started/index.mdx
+++ b/packages/internal/docs/docs/getting-started/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Getting started
+pagination_next: null
 ---
 
 import DocCardList from '@theme/DocCardList';

--- a/packages/internal/docs/docs/getting-started/run-project/run-existing-project.mdx
+++ b/packages/internal/docs/docs/getting-started/run-project/run-existing-project.mdx
@@ -1,6 +1,7 @@
 ---
 title: Run existing project
 description: Run an already existing SaaS Boilerplate project
+pagination_next: working-with-sb/index
 ---
 
 import ProjectName from '../../shared/components/ProjectName.component';

--- a/packages/internal/docs/docs/getting-started/run-project/run-new-project.mdx
+++ b/packages/internal/docs/docs/getting-started/run-project/run-new-project.mdx
@@ -1,6 +1,7 @@
 ---
 title: Run new project
 description: Setup a fresh project with SaaS Boilerplate
+pagination_next: working-with-sb/index
 ---
 
 import ProjectName from '../../shared/components/ProjectName.component';

--- a/packages/internal/docs/docs/introduction/index.mdx
+++ b/packages/internal/docs/docs/introduction/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: What is SaaS Boilerplate?
+pagination_next: null
 ---
 
 import DocCardList from '@theme/DocCardList';

--- a/packages/internal/docs/docs/working-with-sb/index.mdx
+++ b/packages/internal/docs/docs/working-with-sb/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Api reference
+title: Working with SaaS Boilerplate
 pagination_next: null
 ---
 

--- a/packages/internal/docs/sidebars.js
+++ b/packages/internal/docs/sidebars.js
@@ -289,9 +289,8 @@ module.exports = {
       label: 'Working with SaaS Boilerplate',
 
       link: {
-        type: 'generated-index',
-        title: 'Working with SaaS Boilerplate',
-        slug: '/working-with-sb',
+        type: 'doc',
+        id: 'working-with-sb/index',
       },
       items: [
         {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Adjusted documentation next links:
- Removed links from some autogenerated index pages
- Changed next links for `Getting started` pages
