### PR TITLE
fix: Set version to 0.0.1 when git is unable to determine a version in case no tags exist in repository

### DIFF
--- a/packages/internal/cli/src/config/env.ts
+++ b/packages/internal/cli/src/config/env.ts
@@ -33,9 +33,16 @@ export async function loadVersionEnv() {
     return process.env.VERSION;
   }
 
-  const { stdout: versionRaw } = await exec(
-    'git describe --tags --first-parent --abbrev=11 --long --dirty --always',
-  );
+  let versionRaw = '';
+  try {
+    const { stdout } = await exec(
+      'git describe --tags --first-parent --abbrev=11 --long --dirty --always',
+    );
+    versionRaw = stdout;
+  } catch {
+    versionRaw = '0.0.1';
+  }
+
   const version = versionRaw.trim();
   process.env.VERSION = version;
   return version;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines

### What kind of change does this PR introduce?

Bug fix

Closes #397 

### What is the current behavior?

Looks like `git describe` fails when no tags are present in repository or head is in detached state.

### What is the new behavior?

Added a try catch around the git describe code and set version `0.0.1` as default.

### Does this PR introduce a breaking change?

no

