### PR TITLE
fix: Remove command args from telemetry

### DIFF
--- a/packages/internal/cli/src/baseCommand.ts
+++ b/packages/internal/cli/src/baseCommand.ts
@@ -60,7 +60,6 @@ export abstract class BaseCommand<T extends typeof Command> extends Command {
           {
             attributes: {
               ...formatAttrs(this.flags, 'flags'),
-              ...formatAttrs(this.args, 'args'),
             },
           },
           async (span) => {


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes/features)

### What kind of change does this PR introduce?

Removes CLI command args from telemetry data

