### PR TITLE
fix: Enforce emails artifact build before workers build / deploy is executed to make sure emails/renderer/index.umd.js is present

### DIFF
--- a/packages/infra/infra-shared/src/stacks/ci/ciServerless.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciServerless.ts
@@ -24,7 +24,7 @@ export class ServerlessCiConfig extends ServiceCiConfig {
     super(scope, id, { envSettings: props.envSettings });
 
     const buildArtifact = codepipeline.Artifact.artifact(
-      `${props.envSettings.projectEnvName}-workers`
+      `${props.envSettings.projectEnvName}-workers`,
     );
 
     const buildProject = this.createBuildProject(props);
@@ -35,8 +35,8 @@ export class ServerlessCiConfig extends ServiceCiConfig {
           input: props.inputArtifact,
           outputs: [buildArtifact],
         },
-        props
-      )
+        props,
+      ),
     );
 
     const deployProject = this.createDeployProject(props);
@@ -47,14 +47,14 @@ export class ServerlessCiConfig extends ServiceCiConfig {
           input: buildArtifact,
           runOrder: 2,
         },
-        props
-      )
+        props,
+      ),
     );
   }
 
   private createBuildAction(
     actionProps: Partial<codepipelineActions.CodeBuildActionProps>,
-    props: ServerlessCiConfigProps
+    props: ServerlessCiConfigProps,
   ) {
     return new codepipelineActions.CodeBuildAction(<
       codepipelineActions.CodeBuildActionProps
@@ -71,10 +71,7 @@ export class ServerlessCiConfig extends ServiceCiConfig {
 
     const installCommands = this.getAssumeRoleCommands();
     const preBuildCommands = [
-      ...this.getWorkspaceSetupCommands(
-        PnpmWorkspaceFilters.WEBAPP_EMAILS,
-        PnpmWorkspaceFilters.WORKERS
-      ),
+      ...this.getWorkspaceSetupCommands(PnpmWorkspaceFilters.WORKERS),
       this.getECRLoginCommand(),
     ];
     const baseImage = `${GlobalECR.getECRPublicCacheUrl()}/${
@@ -93,11 +90,7 @@ export class ServerlessCiConfig extends ServiceCiConfig {
             commands: preBuildCommands,
           },
           build: {
-            commands: [
-              `pnpm saas workers lint`,
-              'pnpm saas emails build',
-              `pnpm saas workers test`,
-            ],
+            commands: [`pnpm saas workers lint`, `pnpm saas workers test`],
           },
         },
         cache: {
@@ -133,19 +126,19 @@ export class ServerlessCiConfig extends ServiceCiConfig {
       },
       cache: codebuild.Cache.local(
         codebuild.LocalCacheMode.CUSTOM,
-        codebuild.LocalCacheMode.DOCKER_LAYER
+        codebuild.LocalCacheMode.DOCKER_LAYER,
       ),
     });
 
     BootstrapStack.getIamPolicyStatementsForEnvParameters(
-      props.envSettings
+      props.envSettings,
     ).forEach((statement) => {
       dockerAssumeRole.addToPolicy(statement);
       project.addToRolePolicy(statement);
     });
 
     EnvMainStack.getIamPolicyStatementsForEnvParameters(
-      props.envSettings
+      props.envSettings,
     ).forEach((statement) => {
       dockerAssumeRole.addToPolicy(statement);
       project.addToRolePolicy(statement);
@@ -161,7 +154,7 @@ export class ServerlessCiConfig extends ServiceCiConfig {
         effect: iam.Effect.ALLOW,
         actions: ['secretsmanager:*'],
         resources: ['*'],
-      })
+      }),
     );
 
     project.addToRolePolicy(
@@ -169,7 +162,7 @@ export class ServerlessCiConfig extends ServiceCiConfig {
         effect: iam.Effect.ALLOW,
         actions: ['sts:AssumeRole'],
         resources: [dockerAssumeRole.roleArn],
-      })
+      }),
     );
 
     return project;
@@ -177,7 +170,7 @@ export class ServerlessCiConfig extends ServiceCiConfig {
 
   private createDeployAction(
     actionProps: Partial<codepipelineActions.CodeBuildActionProps>,
-    props: ServerlessCiConfigProps
+    props: ServerlessCiConfigProps,
   ) {
     return new codepipelineActions.CodeBuildAction(<
       codepipelineActions.CodeBuildActionProps
@@ -246,14 +239,14 @@ export class ServerlessCiConfig extends ServiceCiConfig {
     });
 
     BootstrapStack.getIamPolicyStatementsForEnvParameters(
-      props.envSettings
+      props.envSettings,
     ).forEach((statement) => {
       dockerAssumeRole.addToPolicy(statement);
       project.addToRolePolicy(statement);
     });
 
     EnvMainStack.getIamPolicyStatementsForEnvParameters(
-      props.envSettings
+      props.envSettings,
     ).forEach((statement) => {
       dockerAssumeRole.addToPolicy(statement);
       project.addToRolePolicy(statement);
@@ -269,7 +262,7 @@ export class ServerlessCiConfig extends ServiceCiConfig {
         effect: iam.Effect.ALLOW,
         actions: ['secretsmanager:*'],
         resources: ['*'],
-      })
+      }),
     );
 
     project.addToRolePolicy(
@@ -277,7 +270,7 @@ export class ServerlessCiConfig extends ServiceCiConfig {
         effect: iam.Effect.ALLOW,
         actions: ['sts:AssumeRole'],
         resources: [dockerAssumeRole.roleArn],
-      })
+      }),
     );
 
     dockerAssumeRole.addToPolicy(
@@ -288,7 +281,7 @@ export class ServerlessCiConfig extends ServiceCiConfig {
           `arn:aws:cloudformation:${stack.region}:${stack.account}:stack/CDKToolkit/*`,
           `arn:aws:cloudformation:${stack.region}:${stack.account}:stack/${props.envSettings.projectEnvName}-workers/*`,
         ],
-      })
+      }),
     );
 
     dockerAssumeRole.addToPolicy(
@@ -310,7 +303,7 @@ export class ServerlessCiConfig extends ServiceCiConfig {
           'states:*',
         ],
         resources: ['*'],
-      })
+      }),
     );
 
     return project;

--- a/packages/internal/cli/src/commands/emails/build.ts
+++ b/packages/internal/cli/src/commands/emails/build.ts
@@ -18,7 +18,7 @@ export default class EmailsBuild extends BaseCommand<typeof EmailsBuild> {
     if (envStage !== ENV_STAGE_LOCAL) {
       await assertChamberInstalled();
       await loadChamberEnv(this, {
-        serviceName: `env-${projectEnvName}-webapp`,
+        serviceName: `env-${projectEnvName}-workers`,
       });
     }
 

--- a/packages/internal/cli/src/commands/emails/secrets.ts
+++ b/packages/internal/cli/src/commands/emails/secrets.ts
@@ -9,7 +9,7 @@ export default class EmailsSecrets extends BaseCommand<typeof EmailsSecrets> {
 
   async run(): Promise<void> {
     this.error(
-      'Emails package do not have their own separate secrets service. Use `saas webapp secrets` instead.'
+      'Emails package do not have their own separate secrets service. Use `saas workers secrets` instead.'
     );
   }
 }

--- a/packages/internal/cli/src/commands/workers/deploy.ts
+++ b/packages/internal/cli/src/commands/workers/deploy.ts
@@ -28,7 +28,7 @@ export default class WorkersDeploy extends BaseCommand<typeof WorkersDeploy> {
     );
     await dockerHubLogin();
 
-    this.log(`Deploying backend:
+    this.log(`Deploying workers:
   envStage: ${color.green(envStage)}
   version: ${color.green(version)}
   AWS account: ${color.green(awsAccountId)}

--- a/packages/workers/package.json
+++ b/packages/workers/package.json
@@ -21,6 +21,7 @@
   "devDependencies": {
     "@sb/core": "*",
     "@sb/tools": "*",
+    "@sb/webapp-emails": "*",
     "esbuild": "0.16.17",
     "serverless": "^3.35.2",
     "serverless-esbuild": "^1.48.0",

--- a/packages/workers/project.json
+++ b/packages/workers/project.json
@@ -46,7 +46,10 @@
         ],
         "parallel": false
       },
-      "dependsOn": ["compose-build-image"]
+      "dependsOn": [
+        { "projects": ["webapp-emails"], "target": "build" },
+        "compose-build-image"
+      ]
     },
     "lint": {
       "executor": "nx:run-commands",
@@ -70,7 +73,10 @@
         "color": true,
         "command": "docker-compose run --rm --entrypoint /bin/bash workers /app/packages/workers/scripts/runtime/run_build.sh"
       },
-      "dependsOn": ["compose-build-image"]
+      "dependsOn": [
+        { "projects": ["webapp-emails"], "target": "build" },
+        "compose-build-image"
+      ]
     }
   },
   "tags": ["service"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1025,6 +1025,9 @@ importers:
       '@sb/tools':
         specifier: '*'
         version: link:../internal/tools
+      '@sb/webapp-emails':
+        specifier: '*'
+        version: link:../webapp-libs/webapp-emails
       esbuild:
         specifier: 0.16.17
         version: 0.16.17


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines

### What kind of change does this PR introduce?

bug fix

### What is the current behavior?

Emails artifact is not built when `saas workers build` or `saas workers deploy` is run.

### What is the new behavior?

Added webapp-emails as a dependency to `workers` and `webapp-emails:build` as a dependency for both `build` and `deploy` targets in workers package.

Changed SSM service to workers during emails build, instead of webapp. Makes much more sense.

### Does this PR introduce a breaking change?

yes. when building emails, SSM variables will be pulled from workers (use `saas workers secrets` to set them) instead of webapp.

