### PR TITLE
fix: Invalid build environment for the docs

### DIFF
--- a/packages/internal/cli/src/commands/docs/build.ts
+++ b/packages/internal/cli/src/commands/docs/build.ts
@@ -18,7 +18,7 @@ export default class DocsBuild extends BaseCommand<typeof DocsBuild> {
     if (envStage !== ENV_STAGE_LOCAL) {
       await assertChamberInstalled();
       await loadChamberEnv(this, {
-        serviceName: `env-${projectEnvName}-webapp`,
+        serviceName: `env-${projectEnvName}-docs`,
       });
     }
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines

### What kind of change does this PR introduce?

Fixes invalid environment loaded when `pnpm saas docs build` called causing the documentation to build without search bar and analytics.

### What is the current behavior?
Docs doesn't build with all features.

### What is the new behavior?
Docs will be built with all desired features.
