### PR TITLE
fix: Prevent API stack from throwing error during deployment when user does not define all domains.

### DIFF
--- a/packages/infra/infra-core/src/lib/env-config.ts
+++ b/packages/infra/infra-core/src/lib/env-config.ts
@@ -122,13 +122,17 @@ async function readConfig(): Promise<ConfigFileContent> {
 }
 
 async function readEnvConfig(): Promise<EnvConfigFileContent> {
+  if (!process.env.SB_DOMAIN_API) {
+    throw new Error('SB_DOMAIN_API env variable has to be defined');
+  }
+
   return {
     webAppConfig: {
       envVariables: {},
     },
     basicAuth: process.env.SB_BASIC_AUTH,
     domains: {
-      api: process.env.SB_DOMAIN_API ?? '',
+      api: process.env.SB_DOMAIN_API,
       webApp: process.env.SB_DOMAIN_WEB_APP ?? '',
       cdn: process.env.SB_DOMAIN_CDN ?? '',
       docs: process.env.SB_DOMAIN_DOCS ?? '',


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines

### What kind of change does this PR introduce?

bug fix
closes #415 

### What is the current behavior?

User will get a very ambiguous error when one of domains is not set.

### What is the new behavior?

We display a clear error when user does not define `SB_DOMAIN_API` variable but also other `SB_DOMAIN_*` vars are mode optional for the API stack.

### Does this PR introduce a breaking change?

no

