### PR TITLE
Fix: App deployment from local repository

### DIFF
--- a/packages/backend/project.json
+++ b/packages/backend/project.json
@@ -86,7 +86,11 @@
       "options": {
         "cwd": "packages/backend",
         "color": true,
-        "commands": ["nx cdk:deploy:api", "nx cdk:deploy:migrations"],
+        "commands": [
+          "nx cdk:deploy:migrations",
+          "pnpm nx run trigger-migrations-job",
+          "nx cdk:deploy:api"
+        ],
         "parallel": false
       }
     },

--- a/packages/infra/infra-shared/package.json
+++ b/packages/infra/infra-shared/package.json
@@ -3,7 +3,7 @@
   "version": "2.3.0",
   "type": "commonjs",
   "scripts": {
-    "bootstrap": "cdk -a 'ts-node --project tsconfig.lib.json -r tsconfig-paths/register src/bootstrap.ts' deploy sb-bootstrap",
+    "bootstrap": "cdk -a \"ts-node --project tsconfig.lib.json -r tsconfig-paths/register src/bootstrap.ts\" deploy sb-bootstrap",
     "deploy:global": "cdk deploy *GlobalStack && cdk deploy *UsEastResourcesStack",
     "diff:global": "cdk diff *GlobalStack && cdk diff *UsEastResourcesStack",
     "deploy:main": "cdk deploy *MainStack",

--- a/packages/internal/cli/src/config/init.ts
+++ b/packages/internal/cli/src/config/init.ts
@@ -20,7 +20,7 @@ export const initConfig = async (
     requireAws = false,
     validateEnvStageVariables = true,
     requireLocalEnvStage = false,
-  }: InitConfigOptions
+  }: InitConfigOptions,
 ) => {
   return tracer.startActiveSpan('initConfig', async (span) => {
     const rootPath = await getRootPath();
@@ -30,14 +30,14 @@ export const initConfig = async (
 
     if (!projectName) {
       context.error(
-        'PROJECT_NAME environmental variable needs to be defined. You can set it in <root>/.env file or in the system'
+        'PROJECT_NAME environmental variable needs to be defined. You can set it in <root>/.env file or in the system',
       );
     }
 
     if (requireLocalEnvStage && envStage !== ENV_STAGE_LOCAL) {
       context.error(
         `This command should only be run on a local environment stage.
-Please call \`saas aws set-env local\` first or open a new terminal.`
+Please call \`saas aws set-env local\` first or open a new terminal.`,
       );
     }
 
@@ -47,8 +47,8 @@ Please call \`saas aws set-env local\` first or open a new terminal.`
       if (envStage === ENV_STAGE_LOCAL && requireAws !== 'allow-local') {
         context.error(
           `Remote environment stage required.\nPlease call \`${color.green(
-            'saas aws set-env [stage-name]'
-          )}\` first. Do not use \`local\` value.`
+            'saas aws set-env [stage-name]',
+          )}\` first. Do not use \`local\` value.`,
         );
       }
 
@@ -61,6 +61,11 @@ Please call \`saas aws set-env local\` first or open a new terminal.`
         awsAccountId = awsMetadata.awsAccountId;
         awsRegion = awsMetadata.awsRegion;
       }
+    }
+
+    if (envStage !== ENV_STAGE_LOCAL) {
+      process.env.COMPOSE_PATH_SEPARATOR = ':';
+      process.env.COMPOSE_FILE = 'docker-compose.yml:docker-compose.ci.yml';
     }
 
     const projectEnvName = `${projectName}-${envStage}`;

--- a/packages/internal/cli/src/lib/secretsEditor.ts
+++ b/packages/internal/cli/src/lib/secretsEditor.ts
@@ -16,13 +16,13 @@ export const runSecretsEditor = async ({
       'compose',
       'run',
       '--rm',
-      '-entrypoint /bin/bash',
+      '--entrypoint /bin/bash',
       'ssm-editor',
       `/scripts/run.sh`,
       serviceName,
     ],
     {
       cwd: rootPath,
-    }
+    },
   );
 };

--- a/packages/internal/docs/docs/aws/deploy-to-aws/create-env-stage-in-repo.mdx
+++ b/packages/internal/docs/docs/aws/deploy-to-aws/create-env-stage-in-repo.mdx
@@ -130,9 +130,3 @@ pnpm saas aws set-var SB_TOOLS_HOSTED_ZONE_ID XYZ
 pnpm saas aws set-var SB_TOOLS_HOSTED_ZONE_NAME example.com
 pnpm saas aws set-var SB_TOOLS_DOMAIN_VERSION_MATRIX status.example.com
 ```
-
-## Env variable validation
-
-You can look up the validator in `packages/internal/core/stage-env-validator.js`, which runs on every `nx` command that
-is executed. It will throw an error if you forget to set any required variables. Feel free to add other variables in
-there if you need.

--- a/packages/internal/docs/docs/aws/deploy-to-aws/create-env-stage-in-repo.mdx
+++ b/packages/internal/docs/docs/aws/deploy-to-aws/create-env-stage-in-repo.mdx
@@ -133,6 +133,6 @@ pnpm saas aws set-var SB_TOOLS_DOMAIN_VERSION_MATRIX status.example.com
 
 ## Env variable validation
 
-You can look up the validator in `packages/internal/core/stage-env-validator.js`, which runs on every `nx` command that
+You can look up the validator in `packages/internal/cli/src/config/env.ts`, which runs on every `nx` command that
 is executed. It will throw an error if you forget to set any required variables. Feel free to add other variables in
 there if you need.

--- a/packages/internal/docs/docs/aws/deploy-to-aws/create-env-stage-in-repo.mdx
+++ b/packages/internal/docs/docs/aws/deploy-to-aws/create-env-stage-in-repo.mdx
@@ -130,3 +130,9 @@ pnpm saas aws set-var SB_TOOLS_HOSTED_ZONE_ID XYZ
 pnpm saas aws set-var SB_TOOLS_HOSTED_ZONE_NAME example.com
 pnpm saas aws set-var SB_TOOLS_DOMAIN_VERSION_MATRIX status.example.com
 ```
+
+## Env variable validation
+
+You can look up the validator in `packages/internal/core/stage-env-validator.js`, which runs on every `nx` command that
+is executed. It will throw an error if you forget to set any required variables. Feel free to add other variables in
+there if you need.

--- a/packages/internal/docs/docs/shared/partials/env-vars/_backend.mdx
+++ b/packages/internal/docs/docs/shared/partials/env-vars/_backend.mdx
@@ -1,7 +1,7 @@
 **Required** variables:
 
 | Name                     | Description                                                                   | Example                             |
-| ------------------------ | ----------------------------------------------------------------------------- | ----------------------------------- |
+|--------------------------|-------------------------------------------------------------------------------|-------------------------------------|
 | `DJANGO_DEBUG`           | [docs](https://docs.djangoproject.com/en/4.2/ref/settings/#std:setting-DEBUG) | `True`                              |
 | `DJANGO_SECRET_KEY`      | [docs](https://docs.djangoproject.com/en/4.2/ref/settings/#secret-key)        | `Zs639zRcb5!9om2@tW2H6XG#Znj^TB^I`  |
 | `HASHID_FIELD_SALT`      | [docs](https://github.com/nshafer/django-hashid-field#hashid_field_salt)      | `t5$^r\*xsMRXn1xjzhRSl8I5Hb3BUW$4U` |

--- a/packages/internal/docs/docs/shared/partials/env-vars/_webapp.mdx
+++ b/packages/internal/docs/docs/shared/partials/env-vars/_webapp.mdx
@@ -1,10 +1,10 @@
 **Required** variables:
 
-| Name                  | Description                 | Example               |
-| --------------------- | --------------------------- | --------------------- |
-| VITE_BASE_API_URL     | Path to access backend API  | `/api`                |
-| WEB_APP_URL           |                             |                       |
-| VITE_EMAIL_ASSETS_URL | Absolute URL to application | `https://example.com` |
+| Name                  | Description                                                                      | Example                                          |
+|-----------------------|----------------------------------------------------------------------------------|--------------------------------------------------|
+| VITE_BASE_API_URL     | Path to access backend API                                                       | `/api`                                           |
+| VITE_WEB_APP_URL      | Absolute URL to application                                                      | `https://app.demo.saas.apptoku.com`              |
+| VITE_EMAIL_ASSETS_URL | Absolute URL to email assets. By default it's `${VITE_WEB_APP_URL}/email-assets` | `https://app.demo.saas.apptoku.com/email-assets` |
 
 import OptionalVars from './_webapp_optional.mdx';
 

--- a/packages/internal/docs/docs/shared/partials/env-vars/_webapp_optional.mdx
+++ b/packages/internal/docs/docs/shared/partials/env-vars/_webapp_optional.mdx
@@ -1,7 +1,7 @@
 **Optional** variables (in order to use contentful or stripe services):
 
 | Name                              | Description                             |
-| --------------------------------- | --------------------------------------- |
+|-----------------------------------|-----------------------------------------|
 | VITE_CONTENTFUL_SPACE             | Contentful Space ID                     |
 | VITE_CONTENTFUL_TOKEN             | Contentful API access token             |
 | VITE_CONTENTFUL_ENV               | Contentful environment name             |

--- a/packages/internal/docs/docs/shared/partials/env-vars/_workers.mdx
+++ b/packages/internal/docs/docs/shared/partials/env-vars/_workers.mdx
@@ -1,7 +1,7 @@
 **Required** variables:
 
 | Name        | Description                                                                                                                         | Example                             |
-| ----------- | ----------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
+|-------------|-------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------|
 | FROM_EMAIL  | Email used in `From` email field                                                                                                    | `admin@exmaple.com`                 |
 | HASHID_SALT | [docs](https://github.com/nshafer/django-hashid-field#hashid_field_salt)                                                            | `t5$^r\*xsMRXn1xjzhRSl8I5Hb3BUW$4U` |
 | JWT_SECRET  | Secret used to decode JWT used in subscriptions. The value needs to be the same as `DJANGO_SECRET_KEY` backend environment variable |                                     |

--- a/packages/workers/workers.conf.yml
+++ b/packages/workers/workers.conf.yml
@@ -48,7 +48,7 @@ iam:
       - "arn:aws:s3:::${self:custom.projectEnvName}-file-uploads-bucket/*"
 
 environment:
-  SENTRY_DSN: ${ssm:/${self:custom.ssmService}/SENTRY_DSN}
+  SENTRY_DSN: ${ssm:/${self:custom.ssmService}/SENTRY_DSN, ''}
   PYTHONPATH: /var/task/__pypackages__/3.9/lib
   ENVIRONMENT_NAME: ${self:provider.stage}
 
@@ -74,9 +74,9 @@ SendEmail:
 SynchronizeContentfulContent:
   environment:
     <<: *envsDb
-    CONTENTFUL_SPACE_ID: ${ssm:/${self:custom.ssmService}/CONTENTFUL_SPACE_ID}
-    CONTENTFUL_ACCESS_TOKEN: ${ssm:/${self:custom.ssmService}/CONTENTFUL_ACCESS_TOKEN}
-    CONTENTFUL_ENVIRONMENT: ${ssm:/${self:custom.ssmService}/CONTENTFUL_ENVIRONMENT}
+    CONTENTFUL_SPACE_ID: ${ssm:/${self:custom.ssmService}/CONTENTFUL_SPACE_ID, '<CHANGE-ME>'}
+    CONTENTFUL_ACCESS_TOKEN: ${ssm:/${self:custom.ssmService}/CONTENTFUL_ACCESS_TOKEN, '<CHANGE-ME>'}
+    CONTENTFUL_ENVIRONMENT: ${ssm:/${self:custom.ssmService}/CONTENTFUL_ENVIRONMENT, '<CHANGE-ME>'}
 
 WebSocketsHandler:
   environment:


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [X] The commit message follows our guidelines
- [X] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Fixes: #425
Related to: #426

This changes fixes problem with the last commands of the AWS deploy instructions (docs: https://docs.demo.saas.apptoku.com/aws/deploy-to-aws/run-deployment-commands).
It fixes two issues:
1. Invalid `ENV_STAGE` value in the workers deployment that leads to wrong stage argument in the sls deployment. This is caused by picking docker-compose.local.yml file instead of docker-compose.ci.yml.
2. Stuck `ApiStack` during deployment caused by invalid order of the migrations during deployment (migrations after `ApiStack` deploy).

### What is the current behavior?


### What is the new behavior?

When `pnpm saas ...` is called in the non `local` env scope (set by `pnpm saas aws set-env {ENV}` the right docker-compose.yml file is picked.
When `pnpm saas deploy` is called, there is the right order of backend migrations and API stack deployment.

### Other information:
Also added some minor changes from the #426, fixed required env variables error for the variables that should be optional in the workers SLS file and added minor documentation fixes.