### PR TITLE
fix: Add chmod +x for the runtime scripts in backend Dockerfile

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -33,6 +33,7 @@ WORKDIR /app
 
 COPY . /app/
 
+RUN chmod +x /app/scripts/runtime/*.sh
 
 FROM backend_build AS static_files
 ENV HASHID_FIELD_SALT='' \


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [X] The commit message follows our guidelines

### What kind of change does this PR introduce?

Fixes missing execute rights in the docker container that is missing on Windows

### Other information:
Related to: #426 
As per message on Discord: https://discord.com/channels/1122849885335597088/1169777357125582958/1174626942964748409
It will fix the issue on Windows machines