### PR TITLE
docs: Add PATH parameter to the init script description in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,20 +91,24 @@ like to create a new project:
 **_Using `npm`:_**
 
 ```bash
-npm init saas-boilerplate
+npm init saas-boilerplate PATH
 ```
 
 **_Using `pnpm`:_**
 
 ```bash
-pnpm create saas-boilerplate
+pnpm create saas-boilerplate PATH
 ```
 
 **_Using `yarn`:_**
 
 ```bash
-yarn create saas-boilerplate
+yarn create saas-boilerplate PATH
 ```
+
+> :information_source: Where `PATH` is a directory name where to initialize project.
+>
+> :warning: **The init directory needs to be empty!**
 
 #### Manual setup
 

--- a/packages/internal/docs/docs/getting-started/run-project/run-new-project.mdx
+++ b/packages/internal/docs/docs/getting-started/run-project/run-new-project.mdx
@@ -25,20 +25,28 @@ You can use a special CLI tool to run a new local instance of the <ProjectName/>
 <Tabs>
   <TabItem value="npm" label="npm" default>
     <CodeBlock>
-      npm init saas-boilerplate
+      npm init saas-boilerplate PATH
     </CodeBlock>
   </TabItem>
   <TabItem value="pnpm" label="pnpm">
     <CodeBlock>
-      pnpm create saas-boilerplate
+      pnpm create saas-boilerplate PATH
     </CodeBlock>
   </TabItem>
   <TabItem value="yarn" label="yarn">
     <CodeBlock>
-      yarn create saas-boilerplate
+      yarn create saas-boilerplate PATH
     </CodeBlock>
   </TabItem>
 </Tabs>
+
+:::info
+
+Where `PATH` is a directory name where to initialize project.
+
+**The init directory needs to be empty!**
+
+:::
 
 After the initialization process is complete, you will be able to start the app as described in the [Start the app](#start-the-app) section of the documentation.
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [X] The commit message follows our guidelines
- [X] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Added info about `PATH` parameter to the init script in docs.

### What is the current behavior?

There is no information about the parameter and some users strugle to initialize the project in the not empty directory.

### What is the new behavior?

There is a clear information that user need to initialize project in empty directory

### Does this PR introduce a breaking change?

No
