### PR TITLE
fix: #454 Freeze awscli version to 1.32.24 in backend Dockerfile

### DIFF
--- a/packages/backend/Dockerfile
+++ b/packages/backend/Dockerfile
@@ -18,7 +18,7 @@ ENV PIP_NO_CACHE_DIR off
 RUN apt-get update && apt-get install -y gcc postgresql-client ca-certificates jq \
   && update-ca-certificates \
   && pip install --upgrade pip \
-  && pip install --no-cache-dir setuptools pdm~=2.5.2 awscli
+  && pip install --no-cache-dir setuptools pdm~=2.5.2 awscli==1.32.24
 
 
 COPY --from=chamber /chamber /bin/chamber


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Fixes #454 

Freeze of awscli version in Dockerfile of backend application.

### What is the current behavior?

Failing with `ImportError: cannot import name 'is_s3express_bucket' from 'botocore.utils'` during container startup.

### What is the new behavior?

Backend application is starting up without errors.

### Does this PR introduce a breaking change?

No

### Other information:
