### PR TITLE
fix: Precommit hook failing on initial commit without NX graph generated

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -4,6 +4,11 @@
 
 . "$(dirname "$0")/_/husky.sh"
 
+# Fix issue with @nx/enforce-module-boundaries eslint plugin throwing error without nx graph
+if [ ! -d "$(dirname "$0")/../.nx" ]; then
+  pnpm nx show projects 1> /dev/null
+fi
+
 echo "🚀 Running pre-commit tasks 🚀"
 npx lint-staged --allow-empty
 echo "🏁 Finished pre-commit tasks 🏁"


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [X] The commit message follows our guidelines

### What kind of change does this PR introduce?

Fixes #446

### What is the current behavior?

`@nx/enforce-module-boundaries` eslint plugin throws an error on initial commit when there is no NX graph generated.
This issue won't occur when called any NX command before commit.

### What is the new behavior?

Added a check in the precommit code that is looking for `.nx` directory and if doesn't exists calls `pnpm nx show projects 1> /dev/null`

### Does this PR introduce a breaking change?

No
