### PR TITLE
fix: Prevent NX from loading .env files when running CLI scripts.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@graphql-codegen/cli": "^5.0.0",
     "@graphql-typed-document-node/core": "^3.2.0",
     "@nx/devkit": "17.1.3",
+    "@nx/eslint": "17.1.3",
     "@nx/eslint-plugin": "17.1.3",
     "@nx/jest": "17.1.3",
     "@nx/js": "17.1.3",
@@ -83,8 +84,7 @@
     "vite": "^4.5.0",
     "vite-plugin-eslint": "^1.8.1",
     "vite-plugin-svgr": "^3.3.0",
-    "vite-tsconfig-paths": "^4.2.1",
-    "@nx/eslint": "17.1.3"
+    "vite-tsconfig-paths": "^4.2.1"
   },
   "dependencies": {
     "@aws-sdk/client-cloudformation": "^3.462.0",
@@ -113,5 +113,10 @@
     "react-router-dom": "6.16.0",
     "regenerator-runtime": "^0.14.0",
     "styled-components": "6.0.8"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "nx@17.1.3": "patches/nx@17.1.3.patch"
+    }
   }
 }

--- a/packages/backend/scripts/build.js
+++ b/packages/backend/scripts/build.js
@@ -7,7 +7,8 @@ const AWS_DEFAULT_REGION = process.env.AWS_DEFAULT_REGION;
 const PROJECT_NAME = process.env.PROJECT_NAME;
 const VERSION = process.env.VERSION;
 const SB_MIRROR_REPOSITORY = process.env.SB_MIRROR_REPOSITORY ?? '';
-const SB_PULL_THROUGH_CACHE_REPOSITORY = process.env.SB_PULL_THROUGH_CACHE_REPOSITORY ?? '';
+const SB_PULL_THROUGH_CACHE_REPOSITORY =
+  process.env.SB_PULL_THROUGH_CACHE_REPOSITORY ?? '';
 
 const stsClient = new STSClient();
 

--- a/packages/internal/cli/src/config/env.ts
+++ b/packages/internal/cli/src/config/env.ts
@@ -48,6 +48,10 @@ export async function loadVersionEnv() {
   return version;
 }
 
+export const loadNxEnv = () => {
+  process.env.NX_LOAD_DOT_ENV_FILES = 'false';
+};
+
 export async function validateStageEnv() {
   return envalid.cleanEnv(process.env, {
     PROJECT_NAME: envalid.str({

--- a/packages/internal/cli/src/config/env.ts
+++ b/packages/internal/cli/src/config/env.ts
@@ -48,7 +48,7 @@ export async function loadVersionEnv() {
   return version;
 }
 
-export const loadNxEnv = () => {
+export const disableNxEnvFiles = () => {
   process.env.NX_LOAD_DOT_ENV_FILES = 'false';
 };
 

--- a/packages/internal/cli/src/config/init.ts
+++ b/packages/internal/cli/src/config/init.ts
@@ -2,7 +2,7 @@ import { Command } from '@oclif/core';
 import { color } from '@oclif/color';
 import { trace } from '@opentelemetry/api';
 
-import { ENV_STAGE_LOCAL, getRootPath, loadVersionEnv } from './env';
+import { ENV_STAGE_LOCAL, getRootPath, loadVersionEnv, loadNxEnv } from './env';
 import { initAWS } from './aws';
 import { loadEnvStage } from './storage';
 
@@ -26,6 +26,7 @@ export const initConfig = async (
     const rootPath = await getRootPath();
     const version = await loadVersionEnv();
     const envStage = await loadEnvStage();
+    loadNxEnv();
     const projectName = process.env.PROJECT_NAME;
 
     if (!projectName) {

--- a/packages/internal/cli/src/config/init.ts
+++ b/packages/internal/cli/src/config/init.ts
@@ -2,7 +2,7 @@ import { Command } from '@oclif/core';
 import { color } from '@oclif/color';
 import { trace } from '@opentelemetry/api';
 
-import { ENV_STAGE_LOCAL, getRootPath, loadVersionEnv, loadNxEnv } from './env';
+import { ENV_STAGE_LOCAL, getRootPath, loadVersionEnv, disableNxEnvFiles } from './env';
 import { initAWS } from './aws';
 import { loadEnvStage } from './storage';
 
@@ -26,7 +26,7 @@ export const initConfig = async (
     const rootPath = await getRootPath();
     const version = await loadVersionEnv();
     const envStage = await loadEnvStage();
-    loadNxEnv();
+    disableNxEnvFiles();
     const projectName = process.env.PROJECT_NAME;
 
     if (!projectName) {

--- a/packages/workers/Dockerfile
+++ b/packages/workers/Dockerfile
@@ -34,6 +34,7 @@ COPY packages/workers/pdm.lock packages/workers/pyproject.toml packages/workers/
 RUN pdm sync
 
 WORKDIR $APP_PATH
+COPY /patches/ $APP_PATH/patches/
 COPY package.json pnpm*.yaml $APP_PATH/
 COPY $SRC_CORE_PATH/package.json $DEST_CORE_PATH/
 COPY $SRC_WORKERS_PATH/package.json $DEST_WORKERS_PATH/

--- a/patches/nx@17.1.3.patch
+++ b/patches/nx@17.1.3.patch
@@ -1,0 +1,13 @@
+diff --git a/src/tasks-runner/run-command.js b/src/tasks-runner/run-command.js
+index cd830d3c34639a5d8a52c12b3975e8c309ba8f9b..8300356271db5e2a815d3b51443a5f6682858181 100644
+--- a/src/tasks-runner/run-command.js
++++ b/src/tasks-runner/run-command.js
+@@ -114,7 +114,7 @@ function setEnvVarsBasedOnArgs(nxArgs, loadDotEnvFiles) {
+     if (nxArgs.outputStyle == 'stream-without-prefixes') {
+         process.env.NX_STREAM_OUTPUT = 'true';
+     }
+-    if (loadDotEnvFiles) {
++    if (loadDotEnvFiles && !process.env.NX_LOAD_DOT_ENV_FILES) {
+         process.env.NX_LOAD_DOT_ENV_FILES = 'true';
+     }
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,13 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
+
+patchedDependencies:
+  nx@17.1.3:
+    hash: gccie2giwxnrau2zf7la4up2fa
+    path: patches/nx@17.1.3.patch
 
 importers:
 
@@ -272,7 +277,7 @@ importers:
         version: 14.0.1
       nx:
         specifier: 17.1.3
-        version: 17.1.3
+        version: 17.1.3(patch_hash=gccie2giwxnrau2zf7la4up2fa)
       nx-cloud:
         specifier: 16.5.2
         version: 16.5.2
@@ -8623,7 +8628,7 @@ packages:
     resolution: {integrity: sha512-9YpfEkUpVqOweqgQvMDcWApNx4jhCqBNH5IByZj302Enp3TLnQSvhuX5Dfr8hNQRQokIpEn6tW8SGTctTM5LXw==}
     hasBin: true
     dependencies:
-      nx: 17.1.3
+      nx: 17.1.3(patch_hash=gccie2giwxnrau2zf7la4up2fa)
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@swc-node/register'
@@ -8699,7 +8704,7 @@ packages:
       ejs: 3.1.9
       enquirer: 2.3.6
       ignore: 5.3.0
-      nx: 17.1.3
+      nx: 17.1.3(patch_hash=gccie2giwxnrau2zf7la4up2fa)
       semver: 7.5.3
       tmp: 0.2.1
       tslib: 2.6.2
@@ -9135,7 +9140,7 @@ packages:
       '@nx/devkit': 17.1.3(nx@17.1.3)
       chalk: 4.1.2
       enquirer: 2.3.6
-      nx: 17.1.3
+      nx: 17.1.3(patch_hash=gccie2giwxnrau2zf7la4up2fa)
       tslib: 2.6.2
       yargs-parser: 21.1.1
     transitivePeerDependencies:
@@ -15241,7 +15246,7 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      browserslist: 4.22.2
+      browserslist: 4.21.10
       caniuse-lite: 1.0.30001538
       fraction.js: 4.3.6
       normalize-range: 0.1.2
@@ -26632,7 +26637,7 @@ packages:
       - debug
     dev: true
 
-  /nx@17.1.3:
+  /nx@17.1.3(patch_hash=gccie2giwxnrau2zf7la4up2fa):
     resolution: {integrity: sha512-6LYoTt01nS1d/dvvYtRs+pEAMQmUVsd2fr/a8+X1cDjWrb8wsf1O3DwlBTqKOXOazpS3eOr0Ukc9N1svbu7uXA==}
     hasBin: true
     requiresBuild: true
@@ -26694,6 +26699,7 @@ packages:
     transitivePeerDependencies:
       - debug
     dev: true
+    patched: true
 
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines

### What kind of change does this PR introduce?

Bug fix
Closes #475 

### What is the current behavior?

NX loads .env files from webapp and backend packages when running CLI commands. Some of variables are interfering with the execution of the script. They should only be loaded by Docker or Vite during runtime of apps, not scripts.

### What is the new behavior?

Patched `nx` package to prevent this behaviour with an ENV variable set within CLI.

### Does this PR introduce a breaking change?

Not a breaking change but if someone used .env files in a wrong way that could cause conflict.

