### PR TITLE
fix: Upload env version CI step fails if there is no status dashboard deployed

### DIFF
--- a/packages/infra/infra-shared/src/stacks/ci/ciPipeline.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciPipeline.ts
@@ -80,11 +80,13 @@ export class CiPipeline extends Construct {
       inputArtifact: sourceOutputArtifact,
     });
 
-    new UploadVersionCiConfig(this, 'UploadVersionConfig', {
-      envSettings: props.envSettings,
-      stage: deployStage,
-      inputArtifact: sourceOutputArtifact,
-    });
+    if (props.envSettings.tools.enabled) {
+      new UploadVersionCiConfig(this, 'UploadVersionConfig', {
+        envSettings: props.envSettings,
+        stage: deployStage,
+        inputArtifact: sourceOutputArtifact,
+      });
+    }
   }
 
   private selectStage(name: string, pipeline: Pipeline) {

--- a/packages/internal/docs/docs/aws/deploy-to-aws/create-env-stage-in-repo.mdx
+++ b/packages/internal/docs/docs/aws/deploy-to-aws/create-env-stage-in-repo.mdx
@@ -121,6 +121,10 @@ pnpm saas aws set-var SB_DEPLOY_BRANCHES master
 
 ### \[Optional\] Set tools env variables
 
+The `tools` package during CI deployment is responsible for uploading the information of the version of deployed
+application on specific environment. Then, you will be able to check currently deployed state in the
+[version matrix](../../../working-with-sb/dev-tools/version-matrix).
+
 To configure `tools` package env variables follow the example below.
 
 ```shell
@@ -130,6 +134,14 @@ pnpm saas aws set-var SB_TOOLS_HOSTED_ZONE_ID XYZ
 pnpm saas aws set-var SB_TOOLS_HOSTED_ZONE_NAME example.com
 pnpm saas aws set-var SB_TOOLS_DOMAIN_VERSION_MATRIX status.example.com
 ```
+
+:::info
+
+If you set `SB_TOOLS_ENABLED` to `true` make sure to deploy **version matrix** component before first CI pipeline run.
+
+Follow the [deployment instructions](../../../working-with-sb/dev-tools/version-matrix#deployment) for more details.
+
+:::
 
 ## Env variable validation
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [X] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Fixes #478

Remove version upload step from the AWS CI when tools are disabled.
Added some clear info about version matrix in the AWS guide.

### What is the current behavior?

Currently last step of the CI pipeline will always fail if there is no version matrix package deployed.

### What is the new behavior?

Upload version step is removed so won't fail;)

### Does this PR introduce a breaking change?

No.

### Other information:
