### PR TITLE
feat: Introduce CI mode

### DIFF
--- a/packages/infra/infra-core/src/lib/env-config.ts
+++ b/packages/infra/infra-core/src/lib/env-config.ts
@@ -22,6 +22,7 @@ declare const process: {
     SB_TOOLS_HOSTED_ZONE_NAME: string;
     SB_TOOLS_HOSTED_ZONE_ID: string;
     SB_TOOLS_DOMAIN_VERSION_MATRIX: string;
+    SB_CI_MODE: string;
   };
 };
 
@@ -64,6 +65,15 @@ interface WebAppConfig {
   envVariables: EnvironmentVariables;
 }
 
+export enum CI_MODE {
+  PARALLEL = 'parallel',
+  SIMPLE = 'simple',
+}
+
+interface CIConfig {
+  mode: CI_MODE;
+}
+
 export interface EnvironmentSettings {
   appBasicAuth: string | null | undefined;
   deployBranches: Array<string>;
@@ -77,11 +87,13 @@ export interface EnvironmentSettings {
   version: string;
   webAppEnvVariables: EnvironmentVariables;
   certificates: CertificatesConfig;
+  CIConfig: CIConfig;
 }
 
 interface ConfigFileContent {
   toolsConfig: ToolsConfig;
   webAppConfig: WebAppConfig;
+  CIConfig: CIConfig;
 }
 
 export interface EnvConfigFileContent {
@@ -109,6 +121,10 @@ async function readConfig(): Promise<ConfigFileContent> {
         versionMatrix: process.env.SB_TOOLS_DOMAIN_VERSION_MATRIX,
       },
     },
+    CIConfig: {
+      mode: process.env.SB_CI_MODE === CI_MODE.SIMPLE
+        ? CI_MODE.SIMPLE : CI_MODE.PARALLEL,
+    }
   };
 }
 
@@ -176,5 +192,6 @@ export async function loadEnvSettings(): Promise<EnvironmentSettings> {
       ...(envConfig?.webAppConfig?.envVariables || {}),
     },
     certificates: envConfig.certificates,
+    CIConfig: config.CIConfig,
   };
 }

--- a/packages/infra/infra-shared/src/stacks/ci/ciBackend.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciBackend.ts
@@ -36,25 +36,25 @@ export class BackendCiConfig extends ServiceCiConfig {
       ),
     );
 
-    const apiDeployProject = this.createApiDeployProject(props);
-    props.deployStage.addAction(
-      this.createDeployAction(
-        'api',
-        {
-          project: apiDeployProject,
-          runOrder: this.getRunOrder(props.deployStage, 2)
-        },
-        props,
-      ),
-    );
-
     const migrationsDeployProject = this.createMigrationsDeployProject(props);
     props.deployStage.addAction(
       this.createDeployAction(
         'migrations',
         {
           project: migrationsDeployProject,
-          runOrder: this.getRunOrder(props.deployStage, 2)
+          runOrder: this.getRunOrder(props.deployStage, 2),
+        },
+        props,
+      ),
+    );
+
+    const apiDeployProject = this.createApiDeployProject(props);
+    props.deployStage.addAction(
+      this.createDeployAction(
+        'api',
+        {
+          project: apiDeployProject,
+          runOrder: this.getRunOrder(props.deployStage, 2),
         },
         props,
       ),
@@ -72,7 +72,7 @@ export class BackendCiConfig extends ServiceCiConfig {
       actionName: `${props.envSettings.projectEnvName}-build-${name}`,
       project: actionProps.project,
       input: props.inputArtifact,
-      runOrder: this.getRunOrder(props.buildStage)
+      runOrder: this.getRunOrder(props.buildStage),
     });
   }
 

--- a/packages/infra/infra-shared/src/stacks/ci/ciBackend.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciBackend.ts
@@ -42,7 +42,7 @@ export class BackendCiConfig extends ServiceCiConfig {
         'api',
         {
           project: apiDeployProject,
-          runOrder: 2,
+          runOrder: this.getRunOrder(props.deployStage, 2)
         },
         props,
       ),
@@ -54,7 +54,7 @@ export class BackendCiConfig extends ServiceCiConfig {
         'migrations',
         {
           project: migrationsDeployProject,
-          runOrder: 2,
+          runOrder: this.getRunOrder(props.deployStage, 2)
         },
         props,
       ),
@@ -72,6 +72,7 @@ export class BackendCiConfig extends ServiceCiConfig {
       actionName: `${props.envSettings.projectEnvName}-build-${name}`,
       project: actionProps.project,
       input: props.inputArtifact,
+      runOrder: this.getRunOrder(props.buildStage)
     });
   }
 

--- a/packages/infra/infra-shared/src/stacks/ci/ciComponents.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciComponents.ts
@@ -51,7 +51,7 @@ export class ComponentsCiConfig extends ServiceCiConfig {
       project: actionProps.project,
       actionName: `${props.envSettings.projectEnvName}-deploy-components`,
       input: props.inputArtifact,
-      runOrder: 1,
+      runOrder: this.getRunOrder(props.deployStage, 1),
     });
   }
 

--- a/packages/infra/infra-shared/src/stacks/ci/ciDocs.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciDocs.ts
@@ -45,7 +45,7 @@ export class DocsCiConfig extends ServiceCiConfig {
         {
           project: deployProject,
           input: buildArtifact,
-          runOrder: 2,
+          runOrder: this.getRunOrder(props.deployStage, 2),
         },
         props,
       ),
@@ -61,6 +61,7 @@ export class DocsCiConfig extends ServiceCiConfig {
     >{
       ...actionProps,
       actionName: `${props.envSettings.projectEnvName}-build-docs`,
+      runOrder: this.getRunOrder(props.buildStage)
     });
   }
 

--- a/packages/infra/infra-shared/src/stacks/ci/ciPipeline.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciPipeline.ts
@@ -66,14 +66,14 @@ export class CiPipeline extends Construct {
       inputArtifact: sourceOutputArtifact,
     });
 
-    new DocsCiConfig(this, 'DocsConfig', {
+    new ServerlessCiConfig(this, 'WorkersConfig', {
       envSettings: props.envSettings,
       buildStage,
       deployStage,
       inputArtifact: sourceOutputArtifact,
     });
 
-    new ServerlessCiConfig(this, 'WorkersConfig', {
+    new DocsCiConfig(this, 'DocsConfig', {
       envSettings: props.envSettings,
       buildStage,
       deployStage,

--- a/packages/infra/infra-shared/src/stacks/ci/ciServerless.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciServerless.ts
@@ -45,7 +45,7 @@ export class ServerlessCiConfig extends ServiceCiConfig {
         {
           project: deployProject,
           input: buildArtifact,
-          runOrder: this.getRunOrder(props.deployStage, 2),
+          runOrder: this.getRunOrder(props.buildStage, 2),
         },
         props,
       ),

--- a/packages/infra/infra-shared/src/stacks/ci/ciServerless.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciServerless.ts
@@ -45,7 +45,7 @@ export class ServerlessCiConfig extends ServiceCiConfig {
         {
           project: deployProject,
           input: buildArtifact,
-          runOrder: 2,
+          runOrder: this.getRunOrder(props.deployStage, 2),
         },
         props,
       ),
@@ -61,6 +61,7 @@ export class ServerlessCiConfig extends ServiceCiConfig {
     >{
       ...actionProps,
       actionName: `${props.envSettings.projectEnvName}-build-workers`,
+      runOrder: this.getRunOrder(props.deployStage),
     });
   }
 

--- a/packages/infra/infra-shared/src/stacks/ci/ciUploadVersion.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciUploadVersion.ts
@@ -26,7 +26,7 @@ export class UploadVersionCiConfig extends ServiceCiConfig {
         {
           project: deployProject,
           input: props.inputArtifact,
-          runOrder: 3,
+          runOrder: this.getRunOrder(props.stage, 3),
         },
         props
       )

--- a/packages/infra/infra-shared/src/stacks/ci/ciWebApp.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciWebApp.ts
@@ -45,7 +45,7 @@ export class WebappCiConfig extends ServiceCiConfig {
         {
           project: deployProject,
           input: buildArtifact,
-          runOrder: 2,
+          runOrder: this.getRunOrder(props.deployStage, 2),
         },
         props,
       ),
@@ -61,6 +61,7 @@ export class WebappCiConfig extends ServiceCiConfig {
     >{
       ...actionProps,
       actionName: `${props.envSettings.projectEnvName}-build-webapp`,
+      runOrder: this.getRunOrder(props.buildStage)
     });
   }
 

--- a/packages/internal/docs/docs/aws/deploy-to-aws/create-env-stage-in-repo.mdx
+++ b/packages/internal/docs/docs/aws/deploy-to-aws/create-env-stage-in-repo.mdx
@@ -87,7 +87,7 @@ CNAME DNS records pointing to CloudFront distribution and Load Balancer need to 
 
 ### \[Optional\] Configure production domain
 
-SaaS Boilerplate creates a certificate that supports `*.[ENV_STAGE].example.com` domains, like
+<ProjectName /> creates a certificate that supports `*.[ENV_STAGE].example.com` domains, like
 `app.production.example.com`. You most likely don't want such domain and need straight up `app.example.com` for your
 production environment. Set a following variable to override the default behaviour:
 
@@ -100,6 +100,32 @@ Without setting this variable you'll encounter an error during deployment
 Resource handler returned message: "Invalid request provided: AWS::CloudFront::Distribution: The certificate that is
 attached to your distribution doesn't cover the alternate domain name (CNAME) that you're trying to add.
 ```
+
+### [Optional] Configuring CI mode
+
+:::caution
+Deploying `<ProjectName />` on a **new AWS account** may result in reaching the AWS CodeBuild concurrent build limit.
+This is a common issue with newly created AWS accounts. To mitigate potential issues during CI builds, it is advisable
+to configure the CI mode to `simple`. For more information about potential issues with new AWS accounts, see
+[Configuring AWS Credentials for New Accounts](./configure-aws-credentials#for-users-with-newly-created-aws-accounts).
+:::
+
+Changing the CI mode affects the execution behavior of CI processes:
+- `parallel` (the default setting): Enables actions in the AWS CodePipeline stages to execute concurrently.
+- `simple`: Ensures actions in the AWS CodePipeline stages are executed sequentially, with only one CodeBuild process
+running at a time.
+
+We recommend utilizing the `parallel` mode for optimal performance and efficiency, provided that the concurrent build
+limits of AWS CodeBuild have been adjusted accordingly.
+
+```shell
+pnpm saas aws set-var SB_CI_MODE <parallel/simple>
+```
+
+:::info
+Note: If you modify the settings for an already deployed environment, it is necessary to
+[redeploy the CI stack](./deploy-infrastructure#deploy-the-infrastructure) to ensure that the changes take effect.
+:::
 
 ### \[Optional\] Protect the website with basic auth
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [X] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Fixes #479 

Added a `simple` CI mode that will reorder AWS CodeBuild inside AWS CodePipeline CI stages. It will change the behavior of the CI to run in non-concurrent mode, which is needed for fresh AWS accounts.

### What is the current behavior?

There are some issues on the fresh AWS accounts because of the concurrent AWS CodeBuild limits.

### What is the new behavior?

This setting allow to workaround the problem.

### Does this PR introduce a breaking change?

No. By default the CI will run in parallel.
