### PR TITLE
fix: Workers docker issues

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+**/node_modules
+.nx
+.saas-boilerplate

--- a/packages/backend/.dockerignore
+++ b/packages/backend/.dockerignore
@@ -1,1 +1,3 @@
 __pypackages__
+node_modules
+**/node_modules

--- a/packages/internal/cli/src/commands/up.ts
+++ b/packages/internal/cli/src/commands/up.ts
@@ -102,6 +102,7 @@ export default class Up extends BaseCommand<typeof Up> {
     await assertDockerIsRunning();
     await dockerHubLogin();
 
+    await runCommand('pnpm', ['saas', 'emails', 'build']);
     await runCommand('pnpm', ['nx', 'run', 'core:docker-compose:up']);
     const backendEndpoint = await getBackendEndpoint(this);
     await waitForBackend(this, { url: backendEndpoint, retryCount: 200 });

--- a/packages/workers/.dockerignore
+++ b/packages/workers/.dockerignore
@@ -1,4 +1,5 @@
 node_modules
+**/node_modules
 .serverless
 .pytest_cache
 __pypackages__

--- a/packages/workers/Dockerfile
+++ b/packages/workers/Dockerfile
@@ -52,4 +52,4 @@ ENV PYTHONPATH=/pkgs/__pypackages__/3.11/lib \
 
 WORKDIR $DEST_WORKERS_PATH
 
-CMD pnpm nx serve workers
+CMD node ./scripts/runtime/local-trigger-server.js


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Fixes #458

This PR includes fixes for 3 different issues that was discovered during debugging #458:
- node_modules from the host where shared to the docker containers causing issues on Windows machines
- issue with the invalid environment variables (PATH) into workers process causing to use python3.9 instead of python3.11. This issue caused the missing module errors in the workers container.
- missing `pnpm saas emails build` command when starting the local environment by `pnpm saas up`

### What is the current behavior?

All of the issues above exists.

### What is the new behavior?

- Fixes incorrect paths in the .dockerignore files
- Removed NX from workers CMD image
- Added `pnpm saas emails build` call into `pnpm saas up`

### Does this PR introduce a breaking change?

Nope.