### PR TITLE
fix: #449 Ensure that docker volume is created when running docs locally

### DIFF
--- a/packages/internal/docs/project.json
+++ b/packages/internal/docs/project.json
@@ -28,7 +28,8 @@
         "color": true,
         "commands": ["nx run backend:build-docs", "pnpm start"],
         "parallel": false
-      }
+      },
+      "dependsOn": ["core:docker-create-volumes"]
     }
   },
   "tags": []


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Fixes #449 

### What is the current behavior?

There is an issue when someone will try to start the docs before the main application. There is a missing docker volume so docs won't start.

### What is the new behavior?

Running create docker volume script before docs start. It will ensure that it's created before running docs even before app startup.

### Does this PR introduce a breaking change?
No.
