### PR TITLE
fix: Remove warning in tests from MSW unhandled requests

### DIFF
--- a/packages/webapp-libs/webapp-api-client/src/tests/mocks/server/handlers/graphql.ts
+++ b/packages/webapp-libs/webapp-api-client/src/tests/mocks/server/handlers/graphql.ts
@@ -2,7 +2,12 @@ import { DefaultBodyType, PathParams, rest } from 'msw';
 
 import { apiURL } from '../../../../api/helpers';
 
-export const mockGraphQuery = (response: DefaultBodyType) =>
-  rest.post<DefaultBodyType, PathParams>(apiURL('/graphql'), (req, res, ctx) => {
+export const mockGraphQuery = (response?: DefaultBodyType) =>
+  rest.post<DefaultBodyType, PathParams>(apiURL('/api/graphql'), (req, res, ctx) => {
+    return res(ctx.json(response));
+  });
+
+export const mockGraphWS = (response?: DefaultBodyType) =>
+  rest.get<DefaultBodyType, PathParams>(apiURL('/api/graphql'), (req, res, ctx) => {
     return res(ctx.json(response));
   });

--- a/packages/webapp-libs/webapp-api-client/src/tests/mocks/server/handlers/index.ts
+++ b/packages/webapp-libs/webapp-api-client/src/tests/mocks/server/handlers/index.ts
@@ -1,2 +1,3 @@
 export * from './auth';
+export * from './graphql';
 //<-- IMPORT API MODULE MOCK -->


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [X] The commit message follows our guidelines

### What kind of change does this PR introduce?

Removes warning in tests from MSW unhandled requests

### What is the current behavior?

Latest updates with websockets introduced warnings in tests from MSW that logs unhandled requests. New WS client sends GET requests to the mocked server (default mocked is not working in this case) and MSW doesn't have it.

### What is the new behavior?

Enabled MSW handlers for `/api/graphql` routes.

### Does this PR introduce a breaking change?

Nope.

### Other information:
