### PR TITLE
Remove the line from  .en.shared file

### DIFF
--- a/packages/backend/.env.shared
+++ b/packages/backend/.env.shared
@@ -17,7 +17,6 @@ TASKS_BASE_HANDLER=common.tasks.TaskLocalInvoke
 DB_CONNECTION={"dbname":"backend","username":"backend","password":"backend","host":"db","port":5432}
 REDIS_CONNECTION=redis://redis:6379
 
-AWS_ENDPOINT_URL=http://localstack:4566
 WORKERS_EVENT_BUS_NAME=local-workers
 
 JWT_AUTH_COOKIE_SECURE=False


### PR DESCRIPTION
Hi there,

I noticed that the AWS_ENDPOINT_URL=http://localstack:4566 line in the packages/backend/.env.shared file is no longer needed, as this flag is now being passed by docker-compose.local.yml. This line is causing the migration job to fail when running pnpm saas deploy as it can't resolve localstack.

To fix this issue, I have removed the AWS_ENDPOINT_URL=http://localstack:4566 line from the packages/backend/.env.shared file. This should resolve the issue and allow the migration job to run successfully.

I have tested this change locally and it seems to be working as expected. I hope this fix will be helpful to others who are experiencing the same issue.

Thank you for your time and consideration.

