### PR TITLE
fix: Fix issue with showing invalid active tenant in selector

### DIFF
--- a/packages/webapp-libs/webapp-tenants/src/providers/currentTenantProvider/currentTenantProvider.storage.ts
+++ b/packages/webapp-libs/webapp-tenants/src/providers/currentTenantProvider/currentTenantProvider.storage.ts
@@ -1,20 +1,21 @@
 import { reportError } from '@sb/webapp-core/utils/reportError';
 
-import { CURRENT_TENANT_STORAGE_KEY } from './currentTenantProvider.types';
+import { CURRENT_TENANT_STORAGE_KEY, CurrentTenantStorageState } from './currentTenantProvider.types';
 
-export const setCurrentTenantStorageState = (tenantId: string) => {
+export const setCurrentTenantStorageState = (storageState: CurrentTenantStorageState) => {
   try {
-    localStorage.setItem(CURRENT_TENANT_STORAGE_KEY, tenantId);
+    const newValue = JSON.stringify(storageState);
+    localStorage.setItem(CURRENT_TENANT_STORAGE_KEY, newValue);
     // On localStorage.setItem, the storage event is only triggered on other tabs and windows.
     // So we manually dispatch a storage event to trigger the subscribe function on the current window as well.
-    window.dispatchEvent(new StorageEvent('storage', { key: CURRENT_TENANT_STORAGE_KEY, newValue: tenantId }));
+    window.dispatchEvent(new StorageEvent('storage', { key: CURRENT_TENANT_STORAGE_KEY, newValue }));
   } catch (e) {
     reportError(e);
   }
 };
 
 export const store = {
-  getSnapshot: () => localStorage.getItem(CURRENT_TENANT_STORAGE_KEY),
+  getSnapshot: () => localStorage.getItem(CURRENT_TENANT_STORAGE_KEY) ?? '{}',
   subscribe: (listener: () => void) => {
     window.addEventListener('storage', listener);
     return () => window.removeEventListener('storage', listener);

--- a/packages/webapp-libs/webapp-tenants/src/providers/currentTenantProvider/currentTenantProvider.types.ts
+++ b/packages/webapp-libs/webapp-tenants/src/providers/currentTenantProvider/currentTenantProvider.types.ts
@@ -5,3 +5,7 @@ export const CURRENT_TENANT_STORAGE_KEY = 'currentTenant';
 export type CurrentTenantProviderProps = {
   storageKey?: string;
 } & PropsWithChildren;
+
+export type CurrentTenantStorageState = {
+  [key: string]: string;
+};


### PR DESCRIPTION
Fix issue with showing invalid active tenant loaded from localStorage that was assigned in other user session

### Please check if the PR fulfills these requirements

- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Currently there is only single tenant id stored in localStorage that keeps the information about last active tenant. Lack of logged user information in this state cause the issue that loads wrong tenant as current tenant where it's missing in the URL.

### What is the current behavior?

Instead of saving only tenant it, the map of `user id => tenant id` is saved so there is no issue between login sessions.

### What is the new behavior?

### Does this PR introduce a breaking change?

Should not. If there will be any error, clearing localStorage data should help.
