### PR TITLE
fix: multi tenancy enum duplicate schema

### DIFF
--- a/packages/backend/apps/multitenancy/schema.py
+++ b/packages/backend/apps/multitenancy/schema.py
@@ -16,6 +16,9 @@ from .tokens import tenant_invitation_token
 from .constants import TenantUserRole
 
 
+TenantUserRoleType = graphene.Enum.from_enum(TenantUserRole)
+
+
 class TenantMembershipType(DjangoObjectType):
     id = graphene.ID(required=True)
     invitation_accepted = graphene.Boolean()
@@ -26,13 +29,14 @@ class TenantMembershipType(DjangoObjectType):
     last_name = graphene.String()
     user_email = graphene.String()
     avatar = graphene.String()
+    role = TenantUserRoleType()
 
     class Meta:
         model = models.TenantMembership
         fields = (
             "id",
             "role",
-            "invitationAccepted",
+            "invitation_accepted",
             "user_id",
             "invitee_email_address",
             "invitation_token",


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

It removes duplicated type for TenantMembershipRole in graphql schema.

### What is the current behavior?

There are two different types for same enum
