### PR TITLE
feat: multi tenancy delete tenant validation

### DIFF
--- a/packages/backend/apps/multitenancy/tests/test_schema.py
+++ b/packages/backend/apps/multitenancy/tests/test_schema.py
@@ -135,14 +135,34 @@ class TestDeleteTenantMutation:
         }
     '''
 
-    def test_delete_tenant(self, graphene_client, user, tenant_factory, tenant_membership_factory):
+    def test_delete_tenant(
+        self,
+        graphene_client,
+        user,
+        tenant_factory,
+        tenant_membership_factory,
+        subscription_schedule_factory,
+        monthly_plan_price,
+    ):
         tenant = tenant_factory(name="Tenant 1", type=TenantType.ORGANIZATION)
+        tenant_id = tenant.id
         tenant_membership_factory(tenant=tenant, user=user, role=TenantUserRole.OWNER)
+        subscription_schedule_factory(
+            phases=[{'items': [{'price': monthly_plan_price.id}], 'trialing': True}], customer__subscriber=tenant
+        )
         graphene_client.force_authenticate(user)
         graphene_client.set_tenant_dependent_context(tenant, TenantUserRole.OWNER)
         executed = self.mutate(graphene_client, {"id": to_global_id("TenantType", tenant.id)})
         response_data = executed["data"]["deleteTenant"]["deletedIds"]
-        assert response_data[0] == to_global_id("TenantType", tenant.id)
+        assert response_data[0] == to_global_id("TenantType", tenant_id)
+
+    def test_delete_default_tenant(self, graphene_client, user, tenant_factory, tenant_membership_factory):
+        tenant = tenant_factory(name="Tenant 1", type=TenantType.DEFAULT)
+        tenant_membership_factory(tenant=tenant, user=user, role=TenantUserRole.OWNER)
+        graphene_client.force_authenticate(user)
+        graphene_client.set_tenant_dependent_context(tenant, TenantUserRole.OWNER)
+        executed = self.mutate(graphene_client, {"id": to_global_id("TenantType", tenant.id)})
+        assert executed["errors"][0]["message"] == "GraphQlValidationError"
 
     def test_user_without_membership(self, graphene_client, user, tenant_factory):
         tenant = tenant_factory(name="Tenant 1", type=TenantType.ORGANIZATION)

--- a/packages/backend/apps/multitenancy/tests/test_schema.py
+++ b/packages/backend/apps/multitenancy/tests/test_schema.py
@@ -156,6 +156,24 @@ class TestDeleteTenantMutation:
         response_data = executed["data"]["deleteTenant"]["deletedIds"]
         assert response_data[0] == to_global_id("TenantType", tenant_id)
 
+    def test_delete_tenant_with_free_plan(
+        self,
+        graphene_client,
+        user,
+        tenant_factory,
+        tenant_membership_factory,
+        subscription_schedule_factory,
+    ):
+        tenant = tenant_factory(name="Tenant 1", type=TenantType.ORGANIZATION)
+        tenant_id = tenant.id
+        tenant_membership_factory(tenant=tenant, user=user, role=TenantUserRole.OWNER)
+        subscription_schedule_factory(phases=None, customer__subscriber=tenant)
+        graphene_client.force_authenticate(user)
+        graphene_client.set_tenant_dependent_context(tenant, TenantUserRole.OWNER)
+        executed = self.mutate(graphene_client, {"id": to_global_id("TenantType", tenant.id)})
+        response_data = executed["data"]["deleteTenant"]["deletedIds"]
+        assert response_data[0] == to_global_id("TenantType", tenant_id)
+
     def test_delete_default_tenant(self, graphene_client, user, tenant_factory, tenant_membership_factory):
         tenant = tenant_factory(name="Tenant 1", type=TenantType.DEFAULT)
         tenant_membership_factory(tenant=tenant, user=user, role=TenantUserRole.OWNER)


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Additional checking and actions for tenant removal mutation.

### What is the current behavior?

All tenants can be removed.

### What is the new behavior?

Blocking tenant delete of type `default` and add subscription cancellation during tenant removal.

### Does this PR introduce a breaking change?

Nope

### Other information:
