### PR TITLE
feat: Add `deps:` type to conventional-changelog

### DIFF
--- a/.versionrc.js
+++ b/.versionrc.js
@@ -96,4 +96,15 @@ module.exports = {
     },
   ],
   tagPrefix: '',
+  types: [
+    { type: 'feat', section: 'Features' },
+    { type: 'fix', section: 'Bug Fixes' },
+    { type: 'deps', section: 'Dependencies' },
+    { type: 'chore', hidden: true },
+    { type: 'docs', hidden: true },
+    { type: 'style', hidden: true },
+    { type: 'refactor', hidden: true },
+    { type: 'perf', hidden: true },
+    { type: 'test', hidden: true },
+  ],
 };


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [X] The commit message follows our guidelines

### What kind of change does this PR introduce?

Add `deps:` type to conventional-changelog configuration so the dependencies updates will be visible in the generated changelog.

