### PR TITLE
fix: Switch from pytz to datetime.timezone package

### DIFF
--- a/packages/backend/apps/finances/serializers.py
+++ b/packages/backend/apps/finances/serializers.py
@@ -1,4 +1,3 @@
-import pytz
 from django.conf import settings
 from django.contrib import messages
 from django.utils import timezone
@@ -136,7 +135,7 @@ class SubscriptionSchedulePhaseItemSerializer(serializers.Serializer):
 
 class StripeTimestampField(serializers.DateTimeField):
     def to_representation(self, value):
-        return super().to_representation(timezone.datetime.fromtimestamp(value, tz=pytz.UTC))
+        return super().to_representation(timezone.datetime.fromtimestamp(value, tz=timezone.utc))
 
 
 class SubscriptionSchedulePhaseSerializer(serializers.Serializer):

--- a/packages/backend/apps/finances/services/subscriptions.py
+++ b/packages/backend/apps/finances/services/subscriptions.py
@@ -1,4 +1,3 @@
-import pytz
 from django.utils import timezone
 from djstripe import models as djstripe_models, enums as djstripe_enums
 
@@ -67,7 +66,7 @@ def get_valid_schedule_phases(schedule: djstripe_models.SubscriptionSchedule):
     return [
         phase
         for phase in schedule.phases
-        if timezone.datetime.fromtimestamp(phase['end_date'], tz=pytz.UTC) > timezone.now()
+        if timezone.datetime.fromtimestamp(phase['end_date'], tz=timezone.utc) > timezone.now()
     ]
 
 
@@ -90,5 +89,5 @@ def is_current_schedule_phase_trialing(schedule: djstripe_models.SubscriptionSch
     if not current_phase['trial_end']:
         return False
 
-    trial_end = timezone.datetime.fromtimestamp(current_phase['trial_end'], tz=pytz.UTC)
+    trial_end = timezone.datetime.fromtimestamp(current_phase['trial_end'], tz=timezone.utc)
     return trial_end > timezone.now()

--- a/packages/backend/common/tasks.py
+++ b/packages/backend/common/tasks.py
@@ -1,10 +1,9 @@
 import json
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 
 import boto3
-import pytz
 import requests
 from django.conf import settings
 
@@ -60,7 +59,7 @@ class Task:
 class TaskLocalInvoke(Task):
     def apply(self, data: dict, due_date: datetime = None):
         if due_date is None:
-            due_date = datetime.now(tz=pytz.utc)
+            due_date = datetime.now(tz=timezone.utc)
 
         entry = self.get_entry(data)
         response = requests.post(


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

It switches from `pytz` package to `django.datetime.timezone` because of security reasons.
