### PR TITLE
fix: Missing *.spec.tsx pattern in multiple tsconfig.spec.json files

### DIFF
--- a/packages/webapp-libs/webapp-contentful/tsconfig.spec.json
+++ b/packages/webapp-libs/webapp-contentful/tsconfig.spec.json
@@ -11,6 +11,7 @@
     "jest.config.ts",
     "src/**/*.test.ts",
     "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
     "src/**/*.d.ts",
     "src/tests/**/*.ts",
     "src/tests/**/*.tsx"

--- a/packages/webapp-libs/webapp-core/tsconfig.json
+++ b/packages/webapp-libs/webapp-core/tsconfig.json
@@ -7,9 +7,7 @@
     "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
-    "types": ["@testing-library/jest-dom"],
-    "noFallthroughCasesInSwitch": true,
-    "jsx": "react-jsx"
+    "noFallthroughCasesInSwitch": true
   },
   "files": [],
   "include": [],

--- a/packages/webapp-libs/webapp-core/tsconfig.spec.json
+++ b/packages/webapp-libs/webapp-core/tsconfig.spec.json
@@ -4,7 +4,8 @@
     "outDir": "../../../dist/out-tsc",
     "module": "commonjs",
     "types": ["jest", "node", "@types/gtag.js"],
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "jsx": "react-jsx"
   },
-  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.tsx", "src/**/*.spec.ts", "src/**/*.d.ts"]
 }

--- a/packages/webapp-libs/webapp-emails/tsconfig.spec.json
+++ b/packages/webapp-libs/webapp-emails/tsconfig.spec.json
@@ -7,5 +7,5 @@
     "esModuleInterop": true,
     "jsx": "react-jsx"
   },
-  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+  "include": ["jest.config.ts", "src/**/*.test.ts", "src/**/*.spec.tsx", "src/**/*.spec.ts", "src/**/*.d.ts"]
 }


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?
`...*.spec.tsx` was missing from `include` array in `tsconfig.spec.json` files across multiple internal packages. That led to many ts errors shown by language server inside editors with missing type declarations etc.

![Screenshot 2024-05-16 at 14 13 25](https://github.com/apptension/saas-boilerplate/assets/39130679/569b88aa-9341-4999-8ec3-63ce9644efd4)

