### PR TITLE
fix: Create default tenant for newly created social users

### DIFF
--- a/packages/backend/apps/multitenancy/pipeline.py
+++ b/packages/backend/apps/multitenancy/pipeline.py
@@ -1,0 +1,6 @@
+from .models import Tenant
+
+
+def create_default_tenant(user=None, is_new=False, *args, **kwargs):
+    if user and is_new:
+        Tenant.objects.get_or_create_user_default_tenant(user)

--- a/packages/backend/apps/multitenancy/tests/test_pipeline.py
+++ b/packages/backend/apps/multitenancy/tests/test_pipeline.py
@@ -1,0 +1,25 @@
+import pytest
+from ..pipeline import create_default_tenant
+
+from ..models import Tenant
+from ..constants import TenantType
+
+pytestmark = pytest.mark.django_db
+
+
+class TestCreateTenantPipeline:
+    def test_create_default_tenant_user_and_is_new(self, user):
+        create_default_tenant(user=user, is_new=True)
+        tenant_exists = Tenant.objects.filter(creator=user, type=TenantType.DEFAULT).exists()
+        assert tenant_exists
+
+    def test_create_default_tenant_user_not_new(self, user):
+        count_before = Tenant.objects.filter(creator=user, type=TenantType.DEFAULT).count()
+        create_default_tenant(user=user, is_new=False)
+        count_after = Tenant.objects.filter(creator=user, type=TenantType.DEFAULT).count()
+        assert count_before == count_after
+
+    def test_create_default_tenant_no_user(self):
+        create_default_tenant(user=None, is_new=True)
+        tenant_exists = Tenant.objects.exists()
+        assert not tenant_exists

--- a/packages/backend/config/settings.py
+++ b/packages/backend/config/settings.py
@@ -278,6 +278,7 @@ SOCIAL_AUTH_PIPELINE = (
     'social_core.pipeline.user.create_user',
     'social_core.pipeline.social_auth.associate_user',
     'social_core.pipeline.social_auth.load_extra_data',
+    'apps.multitenancy.pipeline.create_default_tenant',
     'social_core.pipeline.user.user_details',
 )
 SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS = env.list('SOCIAL_AUTH_ALLOWED_REDIRECT_HOSTS', default=[])


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Creating default tenant for users who register using social apps.

### What is the current behavior?

Default tenant is not created which trigger error on FE.
