### PR TITLE
docs: update README with python3 --version

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The full list with the descriptions can be found in the [features documentation]
 
 #### Optional
 
-- Install [Python](https://www.python.org/downloads/) version 3.11 (which can be checked by running `python3 -v`) and [PDM](https://github.com/pdm-project/pdm/#installation) version 2.3 or above (which can be checked by running
+- Install [Python](https://www.python.org/downloads/) version 3.11 (which can be checked by running `python3 --version`) and [PDM](https://github.com/pdm-project/pdm/#installation) version 2.3 or above (which can be checked by running
   `pdm --version`)
   - You need this one if you want to run `pdm install` command in `packages/backend` or `packages/workers` outside
     docker container


### PR DESCRIPTION
- Change 'python3 -v' to 'python3 --version' in the README
- 'python3 -v' opens the Python interpreter and increases log verbosity, while 'python3 --version' displays the version and exits
- 'python -V' serves the same purpose as noted here https://stackoverflow.com/a/8917907/1048291 and a comment specifies "not to be confused with python -v (lowercase v) which increases the logging verbosity"