### PR TITLE
fix: #604 Fix user export

### DIFF
--- a/packages/backend/infra/stacks/lib/backendTaskRole.ts
+++ b/packages/backend/infra/stacks/lib/backendTaskRole.ts
@@ -31,6 +31,14 @@ export function createBackendTaskRole(
   fileUploadsBucket.grantReadWrite(taskRole);
   fileUploadsBucket.grantPutAcl(taskRole);
 
+  const exportsBucket = s3.Bucket.fromBucketName(
+    scope,
+    'ExportsBucket',
+    EnvComponentsStack.getExportsBucketName(envSettings),
+  );
+  exportsBucket.grantReadWrite(taskRole);
+  exportsBucket.grantPutAcl(taskRole);
+
   const eventBus = events.EventBus.fromEventBusName(
     scope,
     'WorkersEventBus',

--- a/packages/backend/infra/stacks/lib/environment.ts
+++ b/packages/backend/infra/stacks/lib/environment.ts
@@ -35,6 +35,8 @@ export function getBackendEnvironment(
       EnvComponentsStack.getWorkersEventBusName(envSettings),
     AWS_STORAGE_BUCKET_NAME:
       EnvComponentsStack.getFileUploadsBucketName(envSettings),
+    AWS_EXPORTS_STORAGE_BUCKET_NAME:
+      EnvComponentsStack.getExportsBucketName(envSettings),
     AWS_S3_CUSTOM_DOMAIN: envSettings.domains.cdn,
     DB_PROXY_ENDPOINT: Fn.importValue(
       MainDatabase.getDatabaseProxyEndpointOutputExportName(envSettings),


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [X] The commit message follows our guidelines

### What kind of change does this PR introduce?

Fixes #604 

Added `AWS_EXPORTS_STORAGE_BUCKET_NAME` env and allow backend task role to access exports bucket.

### What is the current behavior?

Export functionality fill fail because there is no `AWS_EXPORTS_STORAGE_BUCKET_NAME` set.
