### PR TITLE
fix : #621 Redis cache deployment issue

### DIFF
--- a/packages/infra/infra-shared/src/stacks/main/mainRedisCluster.ts
+++ b/packages/infra/infra-shared/src/stacks/main/mainRedisCluster.ts
@@ -34,7 +34,7 @@ export class MainRedisCluster extends Construct {
       engine: 'redis',
       cacheNodeType: 'cache.t2.micro',
       numCacheNodes: 1,
-      cacheSubnetGroupName: subnetGroup.cacheSubnetGroupName,
+      cacheSubnetGroupName: subnetGroup.ref,
       vpcSecurityGroupIds: [securityGroup.securityGroupId],
     });
 


### PR DESCRIPTION
Updated to use subnetGroup.ref in cacheSubnetGroupName to allow CDK to infer the dependency.

### Please check if the PR fulfills these requirements

- [ X ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

Causes error in deployment when running pnpm saas infra deploy 
https://github.com/apptension/saas-boilerplate/issues/621

### What is the new behavior?

Now deploys without error

### Does this PR introduce a breaking change?

No

### Other information:
