### PR TITLE
fix: Set default value for VITE_EMAIL_ASSETS_URL env

### DIFF
--- a/packages/webapp-libs/webapp-core/src/config/env.ts
+++ b/packages/webapp-libs/webapp-core/src/config/env.ts
@@ -5,7 +5,7 @@ export const ENV = {
   ENVIRONMENT_NAME: process.env.VITE_ENVIRONMENT_NAME,
   SENTRY_DSN: process.env.VITE_SENTRY_DSN,
   WEB_APP_URL: process.env.VITE_WEB_APP_URL ?? '',
-  EMAIL_ASSETS_URL: process.env.VITE_EMAIL_ASSETS_URL ?? '',
+  EMAIL_ASSETS_URL: process.env.VITE_EMAIL_ASSETS_URL ?? '/email-assets',
   PUBLIC_URL: process.env.PUBLIC_URL,
   CONTENTFUL_SPACE: process.env.VITE_CONTENTFUL_SPACE,
   CONTENTFUL_ENV: process.env.VITE_CONTENTFUL_ENV,


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [X] The commit message follows our guidelines
- 
### What kind of change does this PR introduce?

Set default value for VITE_EMAIL_ASSETS_URL env. Without it emails in storybooks doesn't link to the correct assets location (assets are missing).
