### PR TITLE
fix: #599 Use ellipses for long organization names

### DIFF
--- a/packages/webapp-libs/webapp-tenants/src/components/tenantSwitch/tenantSwitch.component.tsx
+++ b/packages/webapp-libs/webapp-tenants/src/components/tenantSwitch/tenantSwitch.component.tsx
@@ -93,8 +93,9 @@ export const TenantSwitch = () => {
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button variant="outline">
-            {currentTenant?.name} <ChevronDown className="ml-2 mr--2" />
+          <Button variant="outline" className="overflow-hidden">
+            <div className="overflow-ellipsis overflow-hidden whitespace-nowrap max-w-full">{currentTenant?.name}</div>
+            <ChevronDown className="ml-2 mr--2" />
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent>


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Use ellipses for long organization names for a current tenant name in tenant switch.
