### PR TITLE
fix: #628 Add selecting avatar to queryset

### DIFF
--- a/packages/backend/apps/notifications/schema.py
+++ b/packages/backend/apps/notifications/schema.py
@@ -119,7 +119,9 @@ class NotificationCreatedSubscription(channels_graphql_ws.Subscription):
     @staticmethod
     @database_sync_to_async
     def get_response(id: str):
-        notification = models.Notification.objects.prefetch_related('issuer', 'issuer__profile').get(id=id)
+        notification = models.Notification.objects.prefetch_related(
+            'issuer', 'issuer__profile', 'issuer__profile__avatar'
+        ).get(id=id)
         return NotificationCreatedSubscription(notification)
 
     @staticmethod


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

After adding profile picture notification broadcasting stops working.

### What is the new behavior?

After adding avatar relation to prefetch_related avatar is prefetched and bug is no longer exists. Notifications are sent correctly.

### Does this PR introduce a breaking change?

Nope

### Other information:
