### PR TITLE
fix: #642 Ignore whole backend/templates directory on precommit linter

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,4 +1,5 @@
 {
   "*.{ts,tsx}": "eslint --fix",
-  "*.{json,md,html}": "prettier --write"
+  "*.{json,md,html}": "prettier --write",
+  "!packages/backend/templates/**": []
 }

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,4 @@
 {
   "*.{ts,tsx}": "eslint --fix",
-  "*.{json,md,html}": "prettier --write",
-  "!packages/backend/templates/**": []
+  "*.{json,md,html}": "prettier --write"
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,5 @@
 /coverage
 
 /.nx/cache
+
+/packages/backend/templates


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

bug fix

### What is the current behavior?

Linter is correcting backend django admin templates which breaks them.

### What is the new behavior?

Ignoring django templates directory

### Does this PR introduce a breaking change?

No
