### PR TITLE
fix(emails): #679 SubscriptionErrorEmail is never sent

### DIFF
--- a/packages/backend/apps/finances/tests/test_webhooks.py
+++ b/packages/backend/apps/finances/tests/test_webhooks.py
@@ -94,7 +94,7 @@ class TestSendSubscriptionErrorEmail:
         webhook_event.invoke_webhook_handlers()
 
         send_email.apply_async.assert_called_with(
-            (subscription.customer.subscriber.email, notifications.SubscriptionErrorEmail.name, None)
+            (subscription.customer.subscriber.email, notifications.SubscriptionErrorEmail.name, {})
         )
 
     @patch('common.emails.send_email')
@@ -113,7 +113,7 @@ class TestSendSubscriptionErrorEmail:
         webhook_event.invoke_webhook_handlers()
 
         send_email.apply_async.assert_called_with(
-            (subscription.customer.subscriber.email, notifications.SubscriptionErrorEmail.name, None)
+            (subscription.customer.subscriber.email, notifications.SubscriptionErrorEmail.name, {})
         )
 
 

--- a/packages/backend/common/emails.py
+++ b/packages/backend/common/emails.py
@@ -38,7 +38,7 @@ class Email(BaseEmail):
             self.data = {}
 
     def send(self, due_date=None):
-        send_data = None
+        send_data = {}
 
         serializer = self.get_serializer(data=self.data)
         if serializer:


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x ] The commit message follows our guidelines
- [ x] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?

Bug fix

### What is the current behavior?

when trying to send a SubscriptionErrorEmail, celery tasks stays in started state, and email is not received on mailcatcher

### What is the new behavior?

Email is now received

### Does this PR introduce a breaking change?

No breaking change

### Other information:

Tests have been adapted to pass OK