### PR TITLE
Fix CiStack IAM policy collision across environments

### DIFF
--- a/packages/infra/infra-shared/src/stacks/ci/ciEntrypoint.ts
+++ b/packages/infra/infra-shared/src/stacks/ci/ciEntrypoint.ts
@@ -30,7 +30,27 @@ export class CiEntrypoint extends Construct {
     });
 
     const externalCiUser = this.retrieveExternalCIUser();
-    this.artifactsBucket.grantWrite(externalCiUser);
+    new iam.Policy(this, 'ExternalCiUserArtifactsPolicy', {
+      policyName: `${props.envSettings.projectEnvName}-ci-artifacts-write`,
+      users: [externalCiUser],
+      statements: [
+        new iam.PolicyStatement({
+          actions: [
+            's3:DeleteObject*',
+            's3:PutObject',
+            's3:PutObjectLegalHold',
+            's3:PutObjectRetention',
+            's3:PutObjectTagging',
+            's3:PutObjectVersionTagging',
+            's3:Abort*',
+          ],
+          resources: [
+            this.artifactsBucket.bucketArn,
+            `${this.artifactsBucket.bucketArn}/*`,
+          ],
+        }),
+      ],
+    });
 
     const trail = new cloudtrail.Trail(this, 'CloudTrail');
     trail.addS3EventSelector(


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce?
Bug fix — CiStack IAM policy collision when deploying 3+ environments

### What is the current behavior?
`grantWrite()` on an imported IAM user creates an inline policy with a deterministic name (`EntrypointExternalCiUserPolicy1903AFEC`) derived from the construct path. This name is identical across all environments. The first two environments deploy successfully (last-writer-wins silently overwrites the policy), but any additional environment fails with "Policy resource was already managed by another stack" due to AWS's `ResourceExistenceCheck` guardrail.

### What is the new behavior?
Replaced `grantWrite()` with an explicit `iam.Policy` using an environment-scoped policy name (`${projectEnvName}-ci-artifacts-write`). Each environment now creates its own uniquely named policy on the shared IAM user. The S3 actions match exactly what `grantWrite()` generates — no permission changes, only naming.

### Does this PR introduce a breaking change?
No. Existing environments will migrate from the shared policy to their own scoped policy on next CiStack redeploy. The old shared policy will be deleted once all environments have migrated.

### Other information:
One file changed: `packages/infra/infra-shared/src/stacks/ci/ciEntrypoint.ts`. Tested across three environments (staging, production, payments) — all CiStacks deployed successfully with no collisions and all pipelines verified working.