### PR TITLE
fix: Bump redis node type

### DIFF
--- a/packages/infra/infra-shared/src/stacks/main/mainRedisCluster.ts
+++ b/packages/infra/infra-shared/src/stacks/main/mainRedisCluster.ts
@@ -32,7 +32,7 @@ export class MainRedisCluster extends Construct {
       clusterName: `${props.envSettings.projectEnvName}-main`,
       autoMinorVersionUpgrade: true,
       engine: 'redis',
-      cacheNodeType: 'cache.t2.micro',
+      cacheNodeType: 'cache.t4g.micro',
       numCacheNodes: 1,
       cacheSubnetGroupName: subnetGroup.ref,
       vpcSecurityGroupIds: [securityGroup.securityGroupId],


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [X] The commit message follows our guidelines

### What kind of change does this PR introduce?

Bump redis cache node type from t2 to t4g.
